### PR TITLE
94 constant accessible scoreboard for players

### DIFF
--- a/src/main/java/org/braekpo1nt/mctmanager/Main.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/Main.java
@@ -79,6 +79,7 @@ public final class Main extends JavaPlugin {
     @Override
     public void onDisable() {
         if (saveGameStateOnDisable && gameManager != null) {
+            gameManager.cancelFastBoardManager();
             try {
                 gameManager.saveGameState();
                 if (gameManager.gameIsRunning()) {

--- a/src/main/java/org/braekpo1nt/mctmanager/Main.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/Main.java
@@ -52,8 +52,6 @@ public final class Main extends JavaPlugin {
             Bukkit.getPluginManager().disablePlugin(this);
         }
         
-        new FastBoardManager(this, gameManager);
-        
         // Listeners
         HubBoundaryListener hubBoundaryListener = new HubBoundaryListener(this);
         BlockEffectsListener blockEffectsListener = new BlockEffectsListener(this);

--- a/src/main/java/org/braekpo1nt/mctmanager/Main.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/Main.java
@@ -8,6 +8,7 @@ import org.braekpo1nt.mctmanager.hub.HubManager;
 import org.braekpo1nt.mctmanager.listeners.BlockEffectsListener;
 import org.braekpo1nt.mctmanager.hub.HubBoundaryListener;
 import org.braekpo1nt.mctmanager.listeners.PlayerJoinListener;
+import org.braekpo1nt.mctmanager.ui.FastBoardManager;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
@@ -50,6 +51,8 @@ public final class Main extends JavaPlugin {
             saveGameStateOnDisable = false;
             Bukkit.getPluginManager().disablePlugin(this);
         }
+        
+        new FastBoardManager(this, gameManager);
         
         // Listeners
         HubBoundaryListener hubBoundaryListener = new HubBoundaryListener(this);

--- a/src/main/java/org/braekpo1nt/mctmanager/color/ColorMap.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/color/ColorMap.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
 import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.ChatColor;
 import org.bukkit.Color;
 
 public class ColorMap {
@@ -38,6 +39,27 @@ public class ColorMap {
         }
     }
     
+    private static final Map<String, ChatColor> CHAT_COLOR_MAP = new HashMap<>();
+    
+    static {
+        CHAT_COLOR_MAP.put("aqua", ChatColor.AQUA);
+        CHAT_COLOR_MAP.put("black", ChatColor.BLACK);
+        CHAT_COLOR_MAP.put("blue", ChatColor.BLUE);
+        CHAT_COLOR_MAP.put("dark_aqua", ChatColor.DARK_AQUA);
+        CHAT_COLOR_MAP.put("dark_blue", ChatColor.DARK_BLUE);
+        CHAT_COLOR_MAP.put("dark_gray", ChatColor.DARK_GRAY);
+        CHAT_COLOR_MAP.put("dark_green", ChatColor.DARK_GREEN);
+        CHAT_COLOR_MAP.put("dark_purple", ChatColor.DARK_PURPLE);
+        CHAT_COLOR_MAP.put("dark_red", ChatColor.DARK_RED);
+        CHAT_COLOR_MAP.put("gold", ChatColor.GOLD);
+        CHAT_COLOR_MAP.put("gray", ChatColor.GRAY);
+        CHAT_COLOR_MAP.put("green", ChatColor.GREEN);
+        CHAT_COLOR_MAP.put("light_purple", ChatColor.LIGHT_PURPLE);
+        CHAT_COLOR_MAP.put("red", ChatColor.RED);
+        CHAT_COLOR_MAP.put("white", ChatColor.WHITE);
+        CHAT_COLOR_MAP.put("yellow", ChatColor.YELLOW);
+    }
+    
     public static NamedTextColor getNamedTextColor(String colorString) {
         NamedTextColor color = NAMED_TEXT_COLOR_MAP.get(colorString.toLowerCase());
         return color != null ? color : NamedTextColor.WHITE;
@@ -57,5 +79,10 @@ public class ColorMap {
                 .filter(color -> color.startsWith(colorString))
                 .sorted()
                 .toList();
+    }
+    
+    public static ChatColor getChatColor(String colorString) {
+        ChatColor color = CHAT_COLOR_MAP.get(colorString.toLowerCase());
+        return color != null ? color : ChatColor.WHITE;
     }
 }

--- a/src/main/java/org/braekpo1nt/mctmanager/games/GameManager.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/GameManager.java
@@ -11,6 +11,7 @@ import org.braekpo1nt.mctmanager.games.gamestate.GameStateStorageUtil;
 import org.braekpo1nt.mctmanager.games.mecha.MechaGame;
 import org.braekpo1nt.mctmanager.hub.HubManager;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.Color;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
@@ -312,7 +313,11 @@ public class GameManager {
     }
     
     public Color getTeamColor(UUID playerUniqueId) {
-        return gameStateStorageUtil.getTeamNamedTextColor(playerUniqueId);
+        return gameStateStorageUtil.getTeamColor(playerUniqueId);
+    }
+    
+    public ChatColor getTeamChatColor(String teamName) {
+        return gameStateStorageUtil.getTeamChatColor(teamName);
     }
     
     /**
@@ -327,8 +332,11 @@ public class GameManager {
         return Component.text(displayName).color(teamColor).decorate(TextDecoration.BOLD);
     }
     
-    public Component getFormattedTeamDisplayName(UUID playerUniqueId) {
-        String teamName = gameStateStorageUtil.getPlayerTeamName(playerUniqueId);
-        return getFormattedTeamDisplayName(teamName);
+    public int getPlayerScore(UUID playerUniqueId) {
+        return gameStateStorageUtil.getPlayerScore(playerUniqueId);
+    }
+    
+    public String getTeamDisplayName(String teamName) {
+        return gameStateStorageUtil.getTeamDisplayName(teamName);
     }
 }

--- a/src/main/java/org/braekpo1nt/mctmanager/games/GameManager.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/GameManager.java
@@ -82,15 +82,6 @@ public class GameManager implements Listener {
         fastBoardManager.removeBoard(player.getUniqueId());
     }
     
-    @EventHandler
-    public void playerJoinEvent(PlayerJoinEvent event) {
-        Player player = event.getPlayer();
-        if (!gameStateStorageUtil.containsPlayer(player.getUniqueId())) {
-            return;
-        }
-        fastBoardManager.givePlayerBoardIfAbsent(player);
-    }
-    
     public Scoreboard getMctScoreboard() {
         return mctScoreboard;
     }

--- a/src/main/java/org/braekpo1nt/mctmanager/games/GameManager.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/GameManager.java
@@ -10,12 +10,14 @@ import org.braekpo1nt.mctmanager.games.footrace.FootRaceGame;
 import org.braekpo1nt.mctmanager.games.gamestate.GameStateStorageUtil;
 import org.braekpo1nt.mctmanager.games.mecha.MechaGame;
 import org.braekpo1nt.mctmanager.hub.HubManager;
+import org.braekpo1nt.mctmanager.ui.FastBoardManager;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Color;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scoreboard.Scoreboard;
 import org.bukkit.scoreboard.Team;
 import org.jetbrains.annotations.NotNull;
@@ -33,6 +35,7 @@ public class GameManager {
     private final FootRaceGame footRaceGame;
     private final MechaGame mechaGame;
     private final HubManager hubManager;
+    private final FastBoardManager fastBoardManager;
     private final GameStateStorageUtil gameStateStorageUtil;
     /**
      * Scoreboard for holding the teams. This private scoreboard can't be
@@ -46,10 +49,22 @@ public class GameManager {
     public GameManager(Main plugin, Scoreboard mctScoreboard, HubManager hubManager) {
         this.plugin = plugin;
         this.mctScoreboard = mctScoreboard;
-        gameStateStorageUtil = new GameStateStorageUtil(plugin);
+        this.gameStateStorageUtil = new GameStateStorageUtil(plugin);
         this.footRaceGame = new FootRaceGame(plugin, this);
         this.mechaGame = new MechaGame(plugin, this);
         this.hubManager = hubManager;
+        this.fastBoardManager = new FastBoardManager(plugin, gameStateStorageUtil);
+        kickOffFastBoardManager();
+    }
+    
+    private void kickOffFastBoardManager() {
+        
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                fastBoardManager.updateMainBoard();
+            }
+        }.runTaskTimer(plugin, 0L, 20L);
     }
     
     public Scoreboard getMctScoreboard() {

--- a/src/main/java/org/braekpo1nt/mctmanager/games/GameManager.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/GameManager.java
@@ -88,7 +88,7 @@ public class GameManager implements Listener {
         if (!gameStateStorageUtil.containsPlayer(player.getUniqueId())) {
             return;
         }
-        fastBoardManager.addBoard(player);
+        fastBoardManager.givePlayerBoardIfAbsent(player);
     }
     
     public Scoreboard getMctScoreboard() {
@@ -221,6 +221,7 @@ public class GameManager implements Listener {
         if (!gameStateStorageUtil.containsTeam(teamName)) {
             return false;
         }
+        this.leavePlayersOnTeam(teamName);
         gameStateStorageUtil.removeTeam(teamName);
         Team team = mctScoreboard.getTeam(teamName);
         team.unregister();
@@ -320,8 +321,17 @@ public class GameManager implements Listener {
         UUID playerUniqueId = player.getUniqueId();
         String teamName = gameStateStorageUtil.getPlayerTeamName(playerUniqueId);
         gameStateStorageUtil.leavePlayer(playerUniqueId);
+        fastBoardManager.removeBoard(playerUniqueId);
         Team team = mctScoreboard.getTeam(teamName);
         team.removePlayer(player);
+    }
+    
+    private void leavePlayersOnTeam(String teamName) throws IOException {
+        List<UUID> playerUniqueIds = gameStateStorageUtil.getPlayerUniqueIdsOnTeam(teamName);
+        for (UUID playerUniqueId : playerUniqueIds) {
+            OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(playerUniqueId);
+            leavePlayer(offlinePlayer);
+        }
     }
     
     public String getTeamName(UUID playerUniqueId) {

--- a/src/main/java/org/braekpo1nt/mctmanager/games/GameManager.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/GameManager.java
@@ -326,4 +326,9 @@ public class GameManager {
         NamedTextColor teamColor = gameStateStorageUtil.getTeamNamedTextColor(teamName);
         return Component.text(displayName).color(teamColor).decorate(TextDecoration.BOLD);
     }
+    
+    public Component getFormattedTeamDisplayName(UUID playerUniqueId) {
+        String teamName = gameStateStorageUtil.getPlayerTeamName(playerUniqueId);
+        return getFormattedTeamDisplayName(teamName);
+    }
 }

--- a/src/main/java/org/braekpo1nt/mctmanager/games/GameManager.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/GameManager.java
@@ -82,6 +82,11 @@ public class GameManager implements Listener {
         fastBoardManager.removeBoard(player.getUniqueId());
     }
     
+    @EventHandler
+    public void playerJoinEvent(PlayerJoinEvent event) {
+        fastBoardManager.updateMainBoard();
+    }
+    
     public Scoreboard getMctScoreboard() {
         return mctScoreboard;
     }

--- a/src/main/java/org/braekpo1nt/mctmanager/games/footrace/FootRaceGame.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/footrace/FootRaceGame.java
@@ -4,7 +4,6 @@ import com.onarandombox.MultiverseCore.api.MVWorldManager;
 import com.onarandombox.MultiverseCore.utils.AnchorManager;
 import fr.mrmicky.fastboard.FastBoard;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.format.NamedTextColor;
 import org.braekpo1nt.mctmanager.Main;
 import org.braekpo1nt.mctmanager.games.GameManager;
 import org.braekpo1nt.mctmanager.games.MCTGame;
@@ -21,7 +20,6 @@ import org.bukkit.inventory.meta.LeatherArmorMeta;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scheduler.BukkitRunnable;
-import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.scoreboard.*;
 import org.bukkit.structure.Structure;
 import org.bukkit.util.BoundingBox;
@@ -44,7 +42,6 @@ public class FootRaceGame implements Listener, MCTGame {
      */
     private final World footRaceWorld;
     private final BoundingBox finishLine = new BoundingBox(2396, 80, 295, 2404, 79, 308);
-    private final ScoreboardManager scoreboardManager;
     private final Main plugin;
     private final GameManager gameManager;
     private int startCountDownTaskID;
@@ -68,7 +65,6 @@ public class FootRaceGame implements Listener, MCTGame {
         this.plugin = plugin;
         this.gameManager = gameManager;
         plugin.getServer().getPluginManager().registerEvents(this, plugin);
-        scoreboardManager = Bukkit.getScoreboardManager();
         MVWorldManager worldManager = Main.multiverseCore.getMVWorldManager();
         this.footRaceWorld = worldManager.getMVWorld("NT").getCBWorld();
     }
@@ -90,7 +86,6 @@ public class FootRaceGame implements Listener, MCTGame {
         startStatusEffectsTask();
         startStartRaceCountdownTask();
         setupTeamOptions();
-        
         gameActive = true;
         Bukkit.getLogger().info("Starting Foot Race game");
     }

--- a/src/main/java/org/braekpo1nt/mctmanager/games/footrace/FootRaceGame.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/footrace/FootRaceGame.java
@@ -79,8 +79,8 @@ public class FootRaceGame implements Listener, MCTGame {
         initializeFastBoards();
         closeGlassBarrier();
         teleportPlayersToStartingPositions();
-        giveBoots();
         clearInventories();
+        giveBoots();
         setPlayersToAdventure();
         clearStatusEffects();
         startStatusEffectsTask();

--- a/src/main/java/org/braekpo1nt/mctmanager/games/footrace/FootRaceGame.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/footrace/FootRaceGame.java
@@ -222,7 +222,7 @@ public class FootRaceGame implements Listener, MCTGame {
                 for (Player participant : participants) {
                     if (!placements.contains(participant.getUniqueId())) {
                         gameManager.getFastBoardManager().updateLine(
-                                participant.getUniqueId(),
+                                participant,
                                 1,
                                 timeString
                         );
@@ -261,7 +261,7 @@ public class FootRaceGame implements Listener, MCTGame {
     private void initializeFastBoards() {
         for (Player participant : participants) {
             gameManager.getFastBoardManager().updateLines(
-                    participant.getUniqueId(),
+                    participant,
                     title,
                     "00:00:000",
                     "",
@@ -274,19 +274,19 @@ public class FootRaceGame implements Listener, MCTGame {
     private void hideFastBoards() {
         for (Player participant : participants) {
             gameManager.getFastBoardManager().updateLines(
-                    participant.getUniqueId()
+                    participant
             );
         }
     }
     
-    private void updateFastBoard(UUID playerUniqueId) {
+    private void updateFastBoard(Player player) {
         long elapsedTime = System.currentTimeMillis() - raceStartTime;
         gameManager.getFastBoardManager().updateLines(
-                playerUniqueId,
+                player,
                 title,
                 getTimeString(elapsedTime),
                 "",
-                String.format("Lap: %d/%d", laps.get(playerUniqueId), MAX_LAPS),
+                String.format("Lap: %d/%d", laps.get(player.getUniqueId()), MAX_LAPS),
                 ""
         );
     }
@@ -294,7 +294,7 @@ public class FootRaceGame implements Listener, MCTGame {
     private void showRaceCompleteFastBoard(Player player) {
         long elapsedTime = System.currentTimeMillis() - raceStartTime;
         gameManager.getFastBoardManager().updateLines(
-                player.getUniqueId(),
+                player,
                 title,
                 getTimeString(elapsedTime),
                 "",
@@ -336,7 +336,7 @@ public class FootRaceGame implements Listener, MCTGame {
                 long elapsedTime = System.currentTimeMillis() - raceStartTime;
                 int newLap = currentLap + 1;
                 laps.put(playerUUID, newLap);
-                updateFastBoard(playerUUID);
+                updateFastBoard(player);
                 player.sendMessage("Lap " + newLap);
                 player.sendMessage(String.format("Finished lap %d in %s", currentLap, getTimeString(elapsedTime)));
                 return;

--- a/src/main/java/org/braekpo1nt/mctmanager/games/footrace/FootRaceGame.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/footrace/FootRaceGame.java
@@ -222,7 +222,7 @@ public class FootRaceGame implements Listener, MCTGame {
                 for (Player participant : participants) {
                     if (!placements.contains(participant.getUniqueId())) {
                         gameManager.getFastBoardManager().updateLine(
-                                participant,
+                                participant.getUniqueId(),
                                 1,
                                 timeString
                         );
@@ -261,7 +261,7 @@ public class FootRaceGame implements Listener, MCTGame {
     private void initializeFastBoards() {
         for (Player participant : participants) {
             gameManager.getFastBoardManager().updateLines(
-                    participant,
+                    participant.getUniqueId(),
                     title,
                     "00:00:000",
                     "",
@@ -274,32 +274,32 @@ public class FootRaceGame implements Listener, MCTGame {
     private void hideFastBoards() {
         for (Player participant : participants) {
             gameManager.getFastBoardManager().updateLines(
-                    participant
+                    participant.getUniqueId()
             );
         }
     }
     
-    private void updateFastBoard(Player player) {
+    private void updateFastBoard(Player participant) {
         long elapsedTime = System.currentTimeMillis() - raceStartTime;
         gameManager.getFastBoardManager().updateLines(
-                player,
+                participant.getUniqueId(),
                 title,
                 getTimeString(elapsedTime),
                 "",
-                String.format("Lap: %d/%d", laps.get(player.getUniqueId()), MAX_LAPS),
+                String.format("Lap: %d/%d", laps.get(participant.getUniqueId()), MAX_LAPS),
                 ""
         );
     }
     
-    private void showRaceCompleteFastBoard(Player player) {
+    private void showRaceCompleteFastBoard(UUID playerUniqueId) {
         long elapsedTime = System.currentTimeMillis() - raceStartTime;
         gameManager.getFastBoardManager().updateLines(
-                player,
+                playerUniqueId,
                 title,
                 getTimeString(elapsedTime),
                 "",
                 "Race Complete!",
-                getPlacementTitle(placements.indexOf(player.getUniqueId()) + 1),
+                getPlacementTitle(placements.indexOf(playerUniqueId) + 1),
                 ""
         );
     }
@@ -369,7 +369,7 @@ public class FootRaceGame implements Listener, MCTGame {
     private void onPlayerFinishedRace(Player player) {
         long elapsedTime = System.currentTimeMillis() - raceStartTime;
         placements.add(player.getUniqueId());
-        showRaceCompleteFastBoard(player);
+        showRaceCompleteFastBoard(player.getUniqueId());
         int placement = placements.indexOf(player.getUniqueId()) + 1;
         int points = calculatePointsForPlacement(placement);
         gameManager.awardPointsToPlayer(player, points);

--- a/src/main/java/org/braekpo1nt/mctmanager/games/footrace/FootRaceGame.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/footrace/FootRaceGame.java
@@ -52,7 +52,6 @@ public class FootRaceGame implements Listener, MCTGame {
     private Map<UUID, Integer> laps;
     private ArrayList<UUID> placements;
     private long raceStartTime;
-    private final Map<UUID, FastBoard> boards = new HashMap<>();
     private final PotionEffect SPEED = new PotionEffect(PotionEffectType.SPEED, 10000, 8, true, false, false);
     private final PotionEffect INVISIBILITY = new PotionEffect(PotionEffectType.INVISIBILITY, 10000, 1, true, false, false);
     private final PotionEffect RESISTANCE = new PotionEffect(PotionEffectType.DAMAGE_RESISTANCE, 70, 200, true, false, false);
@@ -60,6 +59,7 @@ public class FootRaceGame implements Listener, MCTGame {
     private final PotionEffect FIRE_RESISTANCE = new PotionEffect(PotionEffectType.FIRE_RESISTANCE, 70, 1, true, false, false);
     private final PotionEffect SATURATION = new PotionEffect(PotionEffectType.SATURATION, 70, 250, true, false, false);
     private int statusEffectsTaskId;
+    private final String title = ChatColor.BLUE+"Foot Race";
     
     public FootRaceGame(Main plugin, GameManager gameManager) {
         this.plugin = plugin;
@@ -221,10 +221,11 @@ public class FootRaceGame implements Listener, MCTGame {
                 String timeString = getTimeString(elapsedTime);
                 for (Player participant : participants) {
                     if (!placements.contains(participant.getUniqueId())) {
-                        FastBoard board = boards.get(participant.getUniqueId());
-                        if (board != null) {
-                            board.updateLine(0, timeString);
-                        }
+                        gameManager.getFastBoardManager().updateLine(
+                                participant.getUniqueId(),
+                                1,
+                                timeString
+                        );
                     }
                 }
             }
@@ -259,30 +260,30 @@ public class FootRaceGame implements Listener, MCTGame {
     
     private void initializeFastBoards() {
         for (Player participant : participants) {
-            FastBoard board = new FastBoard(participant);
-            board.updateTitle(ChatColor.BLUE+"Foot Race");
-            board.updateLines(
+            gameManager.getFastBoardManager().updateLines(
+                    participant.getUniqueId(),
+                    title,
                     "00:00:000",
                     "",
                     String.format("Lap: %d/%d", laps.get(participant.getUniqueId()), MAX_LAPS),
                     ""
             );
-            boards.put(participant.getUniqueId(), board);
         }
     }
     
     private void hideFastBoards() {
-        for (FastBoard board : boards.values()) {
-            if (!board.isDeleted()) {
-                board.delete();
-            }
+        for (Player participant : participants) {
+            gameManager.getFastBoardManager().updateLines(
+                    participant.getUniqueId()
+            );
         }
     }
     
     private void updateFastBoard(UUID playerUniqueId) {
-        FastBoard board = boards.get(playerUniqueId);
         long elapsedTime = System.currentTimeMillis() - raceStartTime;
-        board.updateLines(
+        gameManager.getFastBoardManager().updateLines(
+                playerUniqueId,
+                title,
                 getTimeString(elapsedTime),
                 "",
                 String.format("Lap: %d/%d", laps.get(playerUniqueId), MAX_LAPS),
@@ -291,9 +292,10 @@ public class FootRaceGame implements Listener, MCTGame {
     }
     
     private void showRaceCompleteFastBoard(Player player) {
-        FastBoard board = boards.get(player.getUniqueId());
         long elapsedTime = System.currentTimeMillis() - raceStartTime;
-        board.updateLines(
+        gameManager.getFastBoardManager().updateLines(
+                player.getUniqueId(),
+                title,
                 getTimeString(elapsedTime),
                 "",
                 "Race Complete!",

--- a/src/main/java/org/braekpo1nt/mctmanager/games/gamestate/GameStateStorageUtil.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/gamestate/GameStateStorageUtil.java
@@ -103,17 +103,6 @@ public class GameStateStorageUtil {
         saveGameState();
     }
     
-    
-//    public void removePlayersOnTeam(String teamName) {
-//        Iterator<MCTPlayer> iterator = gameState.getPlayers().values().iterator();
-//        while (iterator.hasNext()) {
-//            MCTPlayer mctPlayer = iterator.next();
-//            if (mctPlayer.getTeamName().equals(teamName)) {
-//                iterator.remove();
-//            }
-//        }
-//    }
-    
     public void removeTeam(String teamName) throws IOException {
         gameState.removeTeam(teamName);
         saveGameState();

--- a/src/main/java/org/braekpo1nt/mctmanager/games/gamestate/GameStateStorageUtil.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/gamestate/GameStateStorageUtil.java
@@ -103,15 +103,19 @@ public class GameStateStorageUtil {
         saveGameState();
     }
     
+    
+//    public void removePlayersOnTeam(String teamName) {
+//        Iterator<MCTPlayer> iterator = gameState.getPlayers().values().iterator();
+//        while (iterator.hasNext()) {
+//            MCTPlayer mctPlayer = iterator.next();
+//            if (mctPlayer.getTeamName().equals(teamName)) {
+//                iterator.remove();
+//            }
+//        }
+//    }
+    
     public void removeTeam(String teamName) throws IOException {
         gameState.removeTeam(teamName);
-        Iterator<MCTPlayer> iterator = gameState.getPlayers().values().iterator();
-        while (iterator.hasNext()) {
-            MCTPlayer mctPlayer = iterator.next();
-            if (mctPlayer.getTeamName().equals(teamName)) {
-                iterator.remove();
-            }
-        }
         saveGameState();
     }
     

--- a/src/main/java/org/braekpo1nt/mctmanager/games/gamestate/GameStateStorageUtil.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/gamestate/GameStateStorageUtil.java
@@ -6,6 +6,7 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import org.braekpo1nt.mctmanager.Main;
 import org.braekpo1nt.mctmanager.color.ColorMap;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.Color;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.scoreboard.Scoreboard;
@@ -228,7 +229,7 @@ public class GameStateStorageUtil {
      * @param playerUniqueId The UUID of the player to find the team color for
      * @return The color of the player's team
      */
-    public Color getTeamNamedTextColor(UUID playerUniqueId) {
+    public Color getTeamColor(UUID playerUniqueId) {
         String teamName = this.getPlayerTeamName(playerUniqueId);
         String teamColor = gameState.getTeam(teamName).getColor();
         return ColorMap.getColor(teamColor);
@@ -242,5 +243,10 @@ public class GameStateStorageUtil {
     public String getTeamDisplayName(String teamName) {
         MCTTeam team = gameState.getTeam(teamName);
         return team.getDisplayName();
+    }
+    
+    public ChatColor getTeamChatColor(String teamName) {
+        String teamColor = gameState.getTeam(teamName).getColor();
+        return ColorMap.getChatColor(teamColor);
     }
 }

--- a/src/main/java/org/braekpo1nt/mctmanager/games/mecha/MechaGame.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/mecha/MechaGame.java
@@ -46,7 +46,6 @@ public class MechaGame implements MCTGame, Listener {
     private Map<UUID, Integer> killCounts;
     private final World mechaWorld;
     private final MultiverseWorld mvMechaWorld;
-    private Map<UUID, FastBoard> boards = new HashMap<>();
     private int startMechaTaskId;
     private int stopMechaCountdownTaskId;
     /**
@@ -71,6 +70,7 @@ public class MechaGame implements MCTGame, Listener {
     private int borderShrinkingTaskId;
     private List<UUID> livingPlayers;
     private List<UUID> deadPlayers;
+    private final String title = ChatColor.BLUE+"MECHA";
     
     public MechaGame(Main plugin, GameManager gameManager) {
         this.plugin = plugin;
@@ -365,11 +365,13 @@ public class MechaGame implements MCTGame, Listener {
     }
     
     private void addKill(UUID killerUniqueId) {
-        FastBoard board = boards.get(killerUniqueId);
         int oldKillCount = killCounts.get(killerUniqueId);
         int newKillCount = oldKillCount + 1;
         killCounts.put(killerUniqueId, newKillCount);
-        board.updateLine(1, "Kills: " + newKillCount);
+        gameManager.getFastBoardManager().updateLine(
+                killerUniqueId,
+                1, 
+                "Kills: " + newKillCount);
     }
     
     private void initializeWorldBorder() {
@@ -429,24 +431,23 @@ public class MechaGame implements MCTGame, Listener {
     
     private void initializeFastboards() {
         for (Player participant : participants) {
-            FastBoard board = new FastBoard(participant);
-            board.updateTitle(ChatColor.BLUE+"MECHA");
-            board.updateLines(
+            gameManager.getFastBoardManager().updateLines(
+                    participant.getUniqueId(),
+                    title,
                     "",
                     ChatColor.RED+"Kills: 0",
                     "",
                     ChatColor.LIGHT_PURPLE+"Border",
                     ChatColor.LIGHT_PURPLE+"0:00"
             );
-            boards.put(participant.getUniqueId(), board);
         }
     }
     
     private void hideFastBoards() {
-        for (FastBoard board : boards.values()) {
-            if (!board.isDeleted()) {
-                board.delete();
-            }
+        for (Player participant : participants) {
+            gameManager.getFastBoardManager().updateLines(
+                    participant.getUniqueId()
+            );
         }
     }
     
@@ -481,12 +482,14 @@ public class MechaGame implements MCTGame, Listener {
      */
     private void displayBorderShrinkingFor(int duration) {
         String timeString = getTimeString(duration);
-        String line3 = ChatColor.RED+"Shrinking";
-        String line4 = ChatColor.RED+timeString;
+        String borderPhase = ChatColor.RED+"Shrinking";
+        String shrinkDuration = ChatColor.RED+timeString;
         for (Player participant : participants) {
-            FastBoard board = boards.get(participant.getUniqueId());
-            board.updateLine(3, line3);
-            board.updateLine(4, line4);
+            UUID playerUniqueId = participant.getUniqueId();
+            gameManager.getFastBoardManager().updateLine(playerUniqueId, 
+                    4, borderPhase);
+            gameManager.getFastBoardManager().updateLine(playerUniqueId, 
+                    5, shrinkDuration);
         }
     }
     
@@ -496,12 +499,14 @@ public class MechaGame implements MCTGame, Listener {
      */
     private void displayBorderDelayFor(int delay) {
         String timeString = getTimeString(delay);
-        String line3 = ChatColor.LIGHT_PURPLE+"Border";
-        String line4 = ChatColor.LIGHT_PURPLE+timeString;
+        String borderPhase = ChatColor.LIGHT_PURPLE+"Border";
+        String boardDelay = ChatColor.LIGHT_PURPLE+timeString;
         for (Player participant : participants) {
-            FastBoard board = boards.get(participant.getUniqueId());
-            board.updateLine(3, line3);
-            board.updateLine(4, line4);
+            UUID playerUniqueId = participant.getUniqueId();
+            gameManager.getFastBoardManager().updateLine(playerUniqueId,
+                    4, borderPhase);
+            gameManager.getFastBoardManager().updateLine(playerUniqueId, 
+                    5, boardDelay);
         }
     }
     
@@ -509,12 +514,13 @@ public class MechaGame implements MCTGame, Listener {
      * Displays the sudden death message on the FastBoards
      */
     private void displaySuddenDeath() {
-        String line3 = ChatColor.RED+"Sudden death";
-        String line4 = "";
+        String borderPhase = ChatColor.RED+"Sudden death";
         for (Player participant : participants) {
-            FastBoard board = boards.get(participant.getUniqueId());
-            board.updateLine(3, line3);
-            board.updateLine(4, line4);
+            UUID playerUniqueId = participant.getUniqueId();
+            gameManager.getFastBoardManager().updateLine(playerUniqueId,
+                    4, borderPhase);
+            gameManager.getFastBoardManager().updateLine(playerUniqueId,
+                    5, "");
         }
     }
     

--- a/src/main/java/org/braekpo1nt/mctmanager/listeners/BlockEffectsListener.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/listeners/BlockEffectsListener.java
@@ -17,6 +17,9 @@ public class BlockEffectsListener implements Listener {
     
     private boolean blockEffectsEnabled = true;
     
+    private final PotionEffect SPEED = new PotionEffect(PotionEffectType.SPEED, 80, 5, true, false, false);
+    private final PotionEffect JUMP = new PotionEffect(PotionEffectType.JUMP, 140, 7, true, false, false);
+    
     public BlockEffectsListener(Main plugin) {
         plugin.getServer().getPluginManager().registerEvents(this, plugin);
     }
@@ -30,10 +33,10 @@ public class BlockEffectsListener implements Listener {
         Material standingBlock = player.getLocation().add(0, -1, 0).getBlock().getType();
         switch (standingBlock) {
             case MAGENTA_GLAZED_TERRACOTTA:
-                player.addPotionEffect(new PotionEffect(PotionEffectType.SPEED, 80, 7, true, false, false));
+                player.addPotionEffect(SPEED);
                 break;
             case LIME_GLAZED_TERRACOTTA:
-                player.addPotionEffect(new PotionEffect(PotionEffectType.JUMP, 140, 7, true, false, false));
+                player.addPotionEffect(JUMP);
                 break;
             case BEDROCK:
                 player.removePotionEffect(PotionEffectType.JUMP);

--- a/src/main/java/org/braekpo1nt/mctmanager/ui/FastBoardManager.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/ui/FastBoardManager.java
@@ -1,0 +1,80 @@
+package org.braekpo1nt.mctmanager.ui;
+
+import fr.mrmicky.fastboard.FastBoard;
+import net.kyori.adventure.text.Component;
+import org.braekpo1nt.mctmanager.Main;
+import org.braekpo1nt.mctmanager.games.GameManager;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Responsible for displaying the MCT sidebar FastBoard
+ * Utilizes the <a href="https://github.com/MrMicky-FR/FastBoard">FastBoard api</a>
+ */
+public class FastBoardManager implements Listener {
+    
+    private final ConcurrentHashMap<UUID, FastBoard> boards = new ConcurrentHashMap<>();
+    private final GameManager gameManager;
+    
+    public FastBoardManager(Main plugin, GameManager gameManager) {
+        this.gameManager = gameManager;
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+        giveBoardsToAllOnlinePlayers();
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                updateBoards();
+            }
+        }.runTaskTimer(plugin, 0L, 1L);
+    }
+    
+    private void updateBoards() {
+        for (FastBoard board : boards.values()) {
+            
+        }
+    }
+    
+    private void giveBoardsToAllOnlinePlayers() {
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            if (gameManager.hasPlayer(player.getUniqueId())) {
+                addBoard(player);
+            }
+        }
+    }
+    
+    private void addBoard(Player player) {
+        Component teamDisplayName = gameManager.getFormattedTeamDisplayName(player.getUniqueId());
+        FastBoard newBoard = new FastBoard(player);
+        newBoard.updateTitle("MCT #1");
+        newBoard.updateLines(
+                teamDisplayName.toString()
+        );
+    }
+    
+    private void removeBoard(UUID playerUniqueId) {
+        
+    }
+    
+    @EventHandler
+    public void playerQuitEvent(PlayerQuitEvent event) {
+        
+    }
+    
+    @EventHandler
+    public void playerJoinEvent(PlayerJoinEvent event) {
+        Player player = event.getPlayer();
+        if (!gameManager.hasPlayer(player.getUniqueId())) {
+            return;
+        }
+        addBoard(player);
+    }
+    
+}


### PR DESCRIPTION
- Made a centralized FastBoard manager. 
- Games access the fastboard manager to display sidebars to the players
- Shows score and team
- Handles players quitting/joining the server, and being removed or added to teams

## Other changes
- Fixed boots being added before inventories are cleared
- Added a map to ChatColors
- Changed block effect speed from 8 to 6