### PR TITLE
190 notify on deck players

### DIFF
--- a/src/main/java/org/braekpo1nt/mctmanager/Main.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/Main.java
@@ -98,8 +98,12 @@ public class Main extends JavaPlugin {
         }
     }
     
-    //Testing methods for mocking components
+    // Testing methods for mocking components
     public void setFastBoardManager(FastBoardManager fastBoardManager) {
         gameManager.setFastBoardManager(fastBoardManager);
+    }
+    
+    public GameManager getGameManager() {
+        return gameManager;
     }
 }

--- a/src/main/java/org/braekpo1nt/mctmanager/Main.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/Main.java
@@ -102,8 +102,4 @@ public class Main extends JavaPlugin {
     public void setFastBoardManager(FastBoardManager fastBoardManager) {
         gameManager.setFastBoardManager(fastBoardManager);
     }
-    
-    public GameManager getGameManager() {
-        return gameManager;
-    }
 }

--- a/src/main/java/org/braekpo1nt/mctmanager/games/GameManager.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/GameManager.java
@@ -748,5 +748,6 @@ public class GameManager implements Listener {
     
     public void setFastBoardManager(FastBoardManager fastBoardManager) {
         this.fastBoardManager = fastBoardManager;
+        this.fastBoardManager.setGameStateStorageUtil(this.gameStateStorageUtil);
     }
 }

--- a/src/main/java/org/braekpo1nt/mctmanager/games/capturetheflag/CaptureTheFlagGame.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/capturetheflag/CaptureTheFlagGame.java
@@ -116,9 +116,58 @@ public class CaptureTheFlagGame implements MCTGame, Listener {
     
     private void startNextRound() {
         CaptureTheFlagRound nextRound = rounds.get(currentRoundIndex);
+        for (Player participant : participants) {
+            String teamName = gameManager.getTeamName(participant.getUniqueId());
+            Component teamDisplayName = gameManager.getFormattedTeamDisplayName(teamName);
+            String oppositeTeam = nextRound.getOppositeTeam(teamName);
+            if (oppositeTeam != null) {
+                Component oppositeTeamDisplayName = gameManager.getFormattedTeamDisplayName(oppositeTeam);
+                participant.sendMessage(Component.empty()
+                        .append(teamDisplayName)
+                        .append(Component.text(" is competing against "))
+                        .append(oppositeTeamDisplayName)
+                        .append(Component.text(" this round ("))
+                        .append(Component.text(currentRoundIndex + 1))
+                        .append(Component.text("/"))
+                        .append(Component.text(maxRounds))
+                        .append(Component.text(")")));
+            } else {
+                int participantsNextRoundIndex = getTeamsNextRoundIndex(teamName);
+                if (participantsNextRoundIndex < 0) {
+                    participant.sendMessage(Component.empty()
+                            .append(teamDisplayName)
+                            .append(Component.text(" has no more rounds. They've competed against every team.")));
+                } else {
+                    participant.sendMessage(Component.empty()
+                            .append(teamDisplayName)
+                            .append(Component.text(" is not competing in this round ("))
+                            .append(Component.text(currentRoundIndex + 1))
+                            .append(Component.text("/"))
+                            .append(Component.text(maxRounds))
+                            .append(Component.text("). Their next round is "))
+                            .append(Component.text(participantsNextRoundIndex)));
+                }
+            }
+        }
         nextRound.start(participants);
     }
-    
+
+    /**
+     * Gets the index of the next round the given team is in, if they are in a successive round.
+     * @param teamName The teamName to search for
+     * @return The index of the next round the given team is in, -1 if they are not in any of the next rounds.
+     */
+    private int getTeamsNextRoundIndex(@NotNull String teamName) {
+        for (int i = currentRoundIndex + 1; i < rounds.size(); i++) {
+            CaptureTheFlagRound round = rounds.get(i);
+            String oppositeTeam = round.getOppositeTeam(teamName);
+            if (oppositeTeam != null) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
     /**
      * Given n {@link MatchPairing}s, where x is the number of arenas in {@link CaptureTheFlagGame#arenas}
      * if n>=x, returns ceiling(n/x) rounds. Each round should hold between 1 and x matches.

--- a/src/main/java/org/braekpo1nt/mctmanager/games/capturetheflag/CaptureTheFlagGame.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/capturetheflag/CaptureTheFlagGame.java
@@ -116,11 +116,14 @@ public class CaptureTheFlagGame implements MCTGame, Listener {
     
     private void startNextRound() {
         CaptureTheFlagRound nextRound = rounds.get(currentRoundIndex);
+        List<Player> roundParticipants = new ArrayList<>();
+        List<Player> onDeckParticipants = new ArrayList<>();
         for (Player participant : participants) {
             String teamName = gameManager.getTeamName(participant.getUniqueId());
             Component teamDisplayName = gameManager.getFormattedTeamDisplayName(teamName);
             String oppositeTeam = nextRound.getOppositeTeam(teamName);
             if (oppositeTeam != null) {
+                roundParticipants.add(participant);
                 Component oppositeTeamDisplayName = gameManager.getFormattedTeamDisplayName(oppositeTeam);
                 participant.sendMessage(Component.empty()
                         .append(teamDisplayName)
@@ -128,6 +131,7 @@ public class CaptureTheFlagGame implements MCTGame, Listener {
                         .append(oppositeTeamDisplayName)
                         .append(Component.text(" this round.")));
             } else {
+                onDeckParticipants.add(participant);
                 int participantsNextRoundIndex = getTeamsNextRoundIndex(teamName);
                 if (participantsNextRoundIndex < 0) {
                     participant.sendMessage(Component.empty()
@@ -141,7 +145,7 @@ public class CaptureTheFlagGame implements MCTGame, Listener {
                 }
             }
         }
-        nextRound.start(participants);
+        nextRound.start(roundParticipants, onDeckParticipants);
     }
 
     /**

--- a/src/main/java/org/braekpo1nt/mctmanager/games/capturetheflag/CaptureTheFlagGame.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/capturetheflag/CaptureTheFlagGame.java
@@ -122,13 +122,11 @@ public class CaptureTheFlagGame implements MCTGame, Listener {
             String oppositeTeam = nextRound.getOppositeTeam(teamName);
             if (oppositeTeam != null) {
                 Component oppositeTeamDisplayName = gameManager.getFormattedTeamDisplayName(oppositeTeam);
-                Component message = Component.empty()
+                participant.sendMessage(Component.empty()
                         .append(teamDisplayName)
                         .append(Component.text(" is competing against "))
                         .append(oppositeTeamDisplayName)
-                        .append(Component.text(" this round."));
-                String plainText = getPlainText(message);
-                participant.sendMessage(message);
+                        .append(Component.text(" this round.")));
             } else {
                 int participantsNextRoundIndex = getTeamsNextRoundIndex(teamName);
                 if (participantsNextRoundIndex < 0) {
@@ -144,20 +142,6 @@ public class CaptureTheFlagGame implements MCTGame, Listener {
             }
         }
         nextRound.start(participants);
-    }
-    
-    private String getPlainText(Component component) {
-        StringBuilder builder = new StringBuilder();
-        
-        if (component instanceof TextComponent textComponent) {
-            builder.append(textComponent.content());
-        }
-        
-        for (Component child : component.children()) {
-            builder.append(getPlainText(child));
-        }
-        
-        return builder.toString();
     }
 
     /**

--- a/src/main/java/org/braekpo1nt/mctmanager/games/capturetheflag/CaptureTheFlagGame.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/capturetheflag/CaptureTheFlagGame.java
@@ -3,7 +3,7 @@ package org.braekpo1nt.mctmanager.games.capturetheflag;
 import com.onarandombox.MultiverseCore.api.MVWorldManager;
 import com.onarandombox.MultiverseCore.api.MultiverseWorld;
 import com.onarandombox.MultiverseCore.utils.AnchorManager;
-import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.*;
 import org.braekpo1nt.mctmanager.Main;
 import org.braekpo1nt.mctmanager.games.GameManager;
 import org.braekpo1nt.mctmanager.games.interfaces.MCTGame;
@@ -122,11 +122,13 @@ public class CaptureTheFlagGame implements MCTGame, Listener {
             String oppositeTeam = nextRound.getOppositeTeam(teamName);
             if (oppositeTeam != null) {
                 Component oppositeTeamDisplayName = gameManager.getFormattedTeamDisplayName(oppositeTeam);
-                participant.sendMessage(Component.empty()
+                Component message = Component.empty()
                         .append(teamDisplayName)
                         .append(Component.text(" is competing against "))
                         .append(oppositeTeamDisplayName)
-                        .append(Component.text(" this round.")));
+                        .append(Component.text(" this round."));
+                String plainText = getPlainText(message);
+                participant.sendMessage(message);
             } else {
                 int participantsNextRoundIndex = getTeamsNextRoundIndex(teamName);
                 if (participantsNextRoundIndex < 0) {
@@ -142,6 +144,20 @@ public class CaptureTheFlagGame implements MCTGame, Listener {
             }
         }
         nextRound.start(participants);
+    }
+    
+    private String getPlainText(Component component) {
+        StringBuilder builder = new StringBuilder();
+        
+        if (component instanceof TextComponent textComponent) {
+            builder.append(textComponent.content());
+        }
+        
+        for (Component child : component.children()) {
+            builder.append(getPlainText(child));
+        }
+        
+        return builder.toString();
     }
 
     /**

--- a/src/main/java/org/braekpo1nt/mctmanager/games/capturetheflag/CaptureTheFlagGame.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/capturetheflag/CaptureTheFlagGame.java
@@ -126,11 +126,7 @@ public class CaptureTheFlagGame implements MCTGame, Listener {
                         .append(teamDisplayName)
                         .append(Component.text(" is competing against "))
                         .append(oppositeTeamDisplayName)
-                        .append(Component.text(" this round ("))
-                        .append(Component.text(currentRoundIndex + 1))
-                        .append(Component.text("/"))
-                        .append(Component.text(maxRounds))
-                        .append(Component.text(")")));
+                        .append(Component.text(" this round.")));
             } else {
                 int participantsNextRoundIndex = getTeamsNextRoundIndex(teamName);
                 if (participantsNextRoundIndex < 0) {
@@ -140,11 +136,7 @@ public class CaptureTheFlagGame implements MCTGame, Listener {
                 } else {
                     participant.sendMessage(Component.empty()
                             .append(teamDisplayName)
-                            .append(Component.text(" is not competing in this round ("))
-                            .append(Component.text(currentRoundIndex + 1))
-                            .append(Component.text("/"))
-                            .append(Component.text(maxRounds))
-                            .append(Component.text("). Their next round is "))
+                            .append(Component.text(" is not competing in this round. Their next round is "))
                             .append(Component.text(participantsNextRoundIndex)));
                 }
             }

--- a/src/main/java/org/braekpo1nt/mctmanager/games/capturetheflag/CaptureTheFlagMatch.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/capturetheflag/CaptureTheFlagMatch.java
@@ -556,17 +556,6 @@ public class CaptureTheFlagMatch implements Listener {
     }
     
     private void initializeFastBoard(Player participant) {
-        String enemyTeam = matchPairing.northTeam();
-        if (northParticipants.contains(participant)) {
-            enemyTeam = matchPairing.southTeam();
-        }
-        ChatColor enemyColor = gameManager.getTeamChatColor(enemyTeam);
-        String enemyDisplayName = gameManager.getTeamDisplayName(enemyTeam);
-        gameManager.getFastBoardManager().updateLine(
-                participant.getUniqueId(),
-                1,
-                "vs: "+enemyColor+enemyDisplayName
-        );
         gameManager.getFastBoardManager().updateLine(
                 participant.getUniqueId(),
                 4,

--- a/src/main/java/org/braekpo1nt/mctmanager/games/capturetheflag/CaptureTheFlagRound.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/capturetheflag/CaptureTheFlagRound.java
@@ -55,7 +55,7 @@ public class CaptureTheFlagRound {
         }
     }
     
-    public void start(List<Player> newParticipants) {
+    public void start(List<Player> newParticipants, List<Player> newOnDeckParticipants) {
         participants = new ArrayList<>();
         for (Player participant : newParticipants) {
             initializeParticipant(participant);

--- a/src/main/java/org/braekpo1nt/mctmanager/games/capturetheflag/CaptureTheFlagRound.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/capturetheflag/CaptureTheFlagRound.java
@@ -10,6 +10,8 @@ import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -218,5 +220,22 @@ public class CaptureTheFlagRound {
             }
         }
         return false;
+    }
+
+    /**
+     * Gets the opposite team of the given teamName, if the teamName is contained in one of this round's
+     * {@link CaptureTheFlagRound#matches}.
+     * @param teamName The teamName to check for
+     * @return The opposite team in the {@link CaptureTheFlagMatch} which contains the given teamName. Null if
+     * the given teamName is not contained in any of the matches for this round.
+     */
+    public @Nullable String getOppositeTeam(@NotNull String teamName) {
+        for (CaptureTheFlagMatch match : matches) {
+            String oppositeTeam = match.getMatchPairing().oppositeTeam(teamName);
+            if (oppositeTeam != null) {
+                return oppositeTeam;
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/org/braekpo1nt/mctmanager/games/capturetheflag/CaptureTheFlagRound.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/capturetheflag/CaptureTheFlagRound.java
@@ -146,16 +146,8 @@ public class CaptureTheFlagRound {
     private void startMatches() {
         for (CaptureTheFlagMatch match : matches) {
             MatchPairing matchPairing = match.getMatchPairing();
-            List<Player> northParticipants = new ArrayList<>();
-            List<Player> southParticipants = new ArrayList<>();
-            for (Player participant : participants) {
-                String team = gameManager.getTeamName(participant.getUniqueId());
-                if (team.equals(matchPairing.northTeam())) {
-                    northParticipants.add(participant);
-                } else if (team.equals(matchPairing.southTeam())) {
-                    southParticipants.add(participant);
-                }
-            }
+            List<Player> northParticipants = getParticipantsOnTeam(matchPairing.northTeam());
+            List<Player> southParticipants = getParticipantsOnTeam(matchPairing.southTeam());
             match.start(northParticipants, southParticipants);
         }
     }

--- a/src/main/java/org/braekpo1nt/mctmanager/games/capturetheflag/CaptureTheFlagRound.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/capturetheflag/CaptureTheFlagRound.java
@@ -6,6 +6,7 @@ import org.braekpo1nt.mctmanager.games.GameManager;
 import org.braekpo1nt.mctmanager.games.utils.ParticipantInitializer;
 import org.braekpo1nt.mctmanager.ui.TimeStringUtils;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
@@ -22,7 +23,7 @@ import java.util.UUID;
  * when all the matches are over.
  */
 public class CaptureTheFlagRound {
-
+    
     private final CaptureTheFlagGame captureTheFlagGame;
     private final Main plugin;
     private final GameManager gameManager;
@@ -186,6 +187,15 @@ public class CaptureTheFlagRound {
     }
     
     private void initializeFastBoard(Player participant) {
+        String teamName = gameManager.getTeamName(participant.getUniqueId());
+        String enemyTeam = getOppositeTeam(teamName);
+        ChatColor enemyColor = gameManager.getTeamChatColor(enemyTeam);
+        String enemyDisplayName = gameManager.getTeamDisplayName(enemyTeam);
+        gameManager.getFastBoardManager().updateLine(
+                participant.getUniqueId(),
+                1,
+                "vs: "+enemyColor+enemyDisplayName
+        );
         gameManager.getFastBoardManager().updateLine(
                 participant.getUniqueId(),
                 4,

--- a/src/main/java/org/braekpo1nt/mctmanager/games/capturetheflag/CaptureTheFlagRound.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/capturetheflag/CaptureTheFlagRound.java
@@ -29,6 +29,7 @@ public class CaptureTheFlagRound {
     private final GameManager gameManager;
     private List<CaptureTheFlagMatch> matches;
     private List<Player> participants;
+    private List<Player> onDeckParticipants;
     private final Location spawnObservatory;
     private int matchesStartingCountDownTaskId;
 
@@ -57,8 +58,12 @@ public class CaptureTheFlagRound {
     
     public void start(List<Player> newParticipants, List<Player> newOnDeckParticipants) {
         participants = new ArrayList<>();
+        onDeckParticipants = new ArrayList<>();
         for (Player participant : newParticipants) {
             initializeParticipant(participant);
+        }
+        for (Player onDeck : newOnDeckParticipants) {
+            initializeOnDeckParticipant(onDeck);
         }
         startMatchesStartingCountDown();
     }
@@ -73,6 +78,16 @@ public class CaptureTheFlagRound {
         ParticipantInitializer.resetHealthAndHunger(participant);
     }
     
+    private void initializeOnDeckParticipant(Player onDeckParticipant) {
+        onDeckParticipants.add(onDeckParticipant);
+        initializeOndDeckFastBoard(onDeckParticipant);
+        onDeckParticipant.teleport(spawnObservatory);
+        onDeckParticipant.getInventory().clear();
+        onDeckParticipant.setGameMode(GameMode.ADVENTURE);
+        ParticipantInitializer.clearStatusEffects(onDeckParticipant);
+        ParticipantInitializer.resetHealthAndHunger(onDeckParticipant);
+    }
+    
     private void roundIsOver() {
         stop();
         captureTheFlagGame.roundIsOver();
@@ -85,6 +100,9 @@ public class CaptureTheFlagRound {
         for (Player participant : participants) {
             resetParticipant(participant);
         }
+        for (Player onDeckParticipant : onDeckParticipants) {
+            resetOnDeckParticipant(onDeckParticipant);
+        }
         participants.clear();
         matches.clear();
     }
@@ -94,6 +112,13 @@ public class CaptureTheFlagRound {
         participant.setGameMode(GameMode.ADVENTURE);
         ParticipantInitializer.clearStatusEffects(participant);
         ParticipantInitializer.resetHealthAndHunger(participant);
+    }
+    
+    private void resetOnDeckParticipant(Player onDeckParticipant) {
+        onDeckParticipant.getInventory().clear();
+        onDeckParticipant.setGameMode(GameMode.ADVENTURE);
+        ParticipantInitializer.clearStatusEffects(onDeckParticipant);
+        ParticipantInitializer.resetHealthAndHunger(onDeckParticipant);
     }
     
     /**
@@ -177,9 +202,15 @@ public class CaptureTheFlagRound {
     private void displayMatchesStartingCountDown(int secondsLeft) {
         String timeString = TimeStringUtils.getTimeString(secondsLeft);
         for (Player participant : participants) {
-            UUID participantUniqueId = participant.getUniqueId();
             gameManager.getFastBoardManager().updateLine(
-                    participantUniqueId,
+                    participant.getUniqueId(),
+                    5,
+                    timeString
+            );
+        }
+        for (Player participant : onDeckParticipants) {
+            gameManager.getFastBoardManager().updateLine(
+                    participant.getUniqueId(),
                     5,
                     timeString
             );
@@ -195,6 +226,24 @@ public class CaptureTheFlagRound {
                 participant.getUniqueId(),
                 1,
                 "vs: "+enemyColor+enemyDisplayName
+        );
+        gameManager.getFastBoardManager().updateLine(
+                participant.getUniqueId(),
+                4,
+                "Starting in:"
+        );
+        gameManager.getFastBoardManager().updateLine(
+                participant.getUniqueId(),
+                5,
+                "0"
+        );
+    }
+    
+    private void initializeOndDeckFastBoard(Player participant) {
+        gameManager.getFastBoardManager().updateLine(
+                participant.getUniqueId(),
+                1,
+                "On Deck"
         );
         gameManager.getFastBoardManager().updateLine(
                 participant.getUniqueId(),

--- a/src/main/java/org/braekpo1nt/mctmanager/games/capturetheflag/CaptureTheFlagRound.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/capturetheflag/CaptureTheFlagRound.java
@@ -152,6 +152,17 @@ public class CaptureTheFlagRound {
         }
     }
 
+    private List<Player> getParticipantsOnTeam(String teamName) {
+        List<Player> onTeam = new ArrayList<>();
+        for (Player participant : participants) {
+            String participantTeam = gameManager.getTeamName(participant.getUniqueId());
+            if (participantTeam.equals(teamName)) {
+                onTeam.add(participant);
+            }
+        }
+        return onTeam;
+    }
+
     private void cancelAllTasks() {
         Bukkit.getScheduler().cancelTask(matchesStartingCountDownTaskId);
     }

--- a/src/main/java/org/braekpo1nt/mctmanager/games/capturetheflag/MatchPairing.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/capturetheflag/MatchPairing.java
@@ -1,13 +1,32 @@
 package org.braekpo1nt.mctmanager.games.capturetheflag;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 /**
  * A class representing two teams that will fight each other in a match
  * @param northTeam
  * @param southTeam
  */
-public record MatchPairing(String northTeam, String southTeam) {
+public record MatchPairing(@NotNull String northTeam, @NotNull String southTeam) {
     
-    public boolean containsTeam(String teamName) {
+    public boolean containsTeam(@NotNull String teamName) {
         return northTeam.equals(teamName) || southTeam.equals(teamName);
+    }
+
+    /**
+     * Gets the opposite team of the given team, if the MatchPairing contains the given team. 
+     * If you give the team name of the northTeam, you get the southTeam, and vice versa.
+     * @param teamName The team name to get the opposite team of.
+     * @return The team name of the opposite team. Null if this MatchPairing does not contain the given teamName.
+     */
+    public @Nullable String oppositeTeam(@NotNull String teamName) {
+        if (northTeam.equals(teamName)) {
+            return southTeam;
+        }
+        if (southTeam.equals((teamName))) {
+            return northTeam;
+        }
+        return null;
     }
 }

--- a/src/main/java/org/braekpo1nt/mctmanager/ui/FastBoardManager.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/ui/FastBoardManager.java
@@ -31,7 +31,7 @@ public class FastBoardManager {
         }
     }
     
-    private synchronized void updateMainBoardForPlayer(Player player) {
+    protected synchronized void updateMainBoardForPlayer(Player player) {
         boolean playerHasBoard = givePlayerBoardIfAbsent(player);
         if (!playerHasBoard) {
             return;
@@ -51,7 +51,7 @@ public class FastBoardManager {
      * @param player The player
      * @return true if the player got a board or already has a board, false if not
      */
-    private synchronized boolean givePlayerBoardIfAbsent(Player player) {
+    protected synchronized boolean givePlayerBoardIfAbsent(Player player) {
         UUID playerUniqueId = player.getUniqueId();
         if (boards.containsKey(playerUniqueId)) {
             return true;
@@ -62,8 +62,8 @@ public class FastBoardManager {
         }
         return false;
     }
-
-    private synchronized void addBoard(Player player) {
+    
+    protected synchronized void addBoard(Player player) {
         FastBoard newBoard = new FastBoard(player);
         newBoard.updateTitle(this.EVENT_TITLE);
         String[] mainLines = getMainLines(player.getUniqueId());
@@ -76,7 +76,7 @@ public class FastBoardManager {
         boards.put(player.getUniqueId(), newBoard);
     }
     
-    private String[] getMainLines(UUID playerUniqueId) {
+    protected String[] getMainLines(UUID playerUniqueId) {
         String teamName = gameStateStorageUtil.getPlayerTeamName(playerUniqueId);
         String teamDisplayName = gameStateStorageUtil.getTeamDisplayName(teamName);
         ChatColor teamChatColor = gameStateStorageUtil.getTeamChatColor(teamName);

--- a/src/main/java/org/braekpo1nt/mctmanager/ui/FastBoardManager.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/ui/FastBoardManager.java
@@ -17,9 +17,9 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class FastBoardManager {
     
-    private final String EVENT_TITLE = ChatColor.BOLD + "" + ChatColor.DARK_RED + "MCT #2";
+    protected final String EVENT_TITLE = ChatColor.BOLD + "" + ChatColor.DARK_RED + "MCT #2";
     private final ConcurrentHashMap<UUID, FastBoard> boards = new ConcurrentHashMap<>();
-    private final GameStateStorageUtil gameStateStorageUtil;
+    protected GameStateStorageUtil gameStateStorageUtil;
     
     public FastBoardManager(GameStateStorageUtil gameStateStorageUtil) {
         this.gameStateStorageUtil = gameStateStorageUtil;
@@ -142,6 +142,12 @@ public class FastBoardManager {
             }
             iterator.remove();
         }
+    }
+    
+    // Test methods
+    
+    public void setGameStateStorageUtil(GameStateStorageUtil gameStateStorageUtil) {
+        this.gameStateStorageUtil = gameStateStorageUtil;
     }
     
 }

--- a/src/test/java/org/braekpo1nt/mctmanager/MyPlayerMock.java
+++ b/src/test/java/org/braekpo1nt/mctmanager/MyPlayerMock.java
@@ -3,7 +3,9 @@ package org.braekpo1nt.mctmanager;
 import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.entity.PlayerMock;
 import io.papermc.paper.entity.LookAnchor;
+import net.kyori.adventure.text.*;
 import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Assertions;
 
 import java.util.UUID;
 
@@ -19,4 +21,53 @@ public class MyPlayerMock extends PlayerMock {
     
     @Override
     public void lookAt(double x, double y, double z, @NotNull LookAnchor playerAnchor) {}
+    
+    /**
+     * Asserts that the plaintext version of the next message sent to the player is equal to the 
+     * expected message regardless of formatting.
+     * @param expected The expected plaintext message
+     */
+    public void assertSaidPlaintext(@NotNull String expected) {
+        Component comp = nextComponentMessage();
+        if (comp == null) {
+            Assertions.fail("No more messages were sent. Expected \"" + expected + "\"");
+        }
+        else {
+            String plainText = toPlainText(comp);
+            Assertions.assertEquals(expected, plainText);
+        }
+    }
+    
+    /**
+     * Takes in a Component with 1 or more children, and converts it to a plaintext string without formatting.
+     * Assumes it is made up of TextComponents and empty components.
+     * @param component The component to get the plaintext version of
+     * @return The concatenation of the contents() of the TextComponent children that this component is made of
+     */
+    String toPlainText(Component component) {
+        StringBuilder builder = new StringBuilder();
+        
+        if (component instanceof TextComponent textComponent) {
+            builder.append(textComponent.content());
+        }
+        else if (component instanceof TranslatableComponent) {
+            for (Component arg : ((TranslatableComponent) component).args()) {
+                builder.append(toPlainText(arg));
+            }
+        } else if (component instanceof ScoreComponent scoreComponent) {
+            builder.append(scoreComponent.name());
+        } else if (component instanceof SelectorComponent selectorComponent) {
+            builder.append(selectorComponent.pattern());
+        } else if (component instanceof KeybindComponent keybindComponent) {
+            builder.append(keybindComponent.keybind());
+        } else if (component instanceof NBTComponent<?, ?> nbtComponent) {
+            builder.append(nbtComponent.nbtPath());
+        }
+        
+        for (Component child : component.children()) {
+            builder.append(toPlainText(child));
+        }
+        
+        return builder.toString();
+    }
 }

--- a/src/test/java/org/braekpo1nt/mctmanager/games/capturetheflag/CaptureTheFlagTest.java
+++ b/src/test/java/org/braekpo1nt/mctmanager/games/capturetheflag/CaptureTheFlagTest.java
@@ -72,22 +72,16 @@ public class CaptureTheFlagTest {
         }
     }
     
-    PlayerMock createParticipant(String name, String teamName, String displayName, NamedTextColor teamColor) {
+    PlayerMock createParticipant(String name, String teamName, String displayName) {
         PlayerMock player = new MyPlayerMock(server, name);
         server.addPlayer(player);
         plugin.getMctCommand().onCommand(sender, command, "mct", new String[]{"team", "join", teamName, player.getName()});
-        Component formattedDisplayName = formatTeamDisplayName(displayName, teamColor);
-        player.assertSaid(Component.text("You've been joined to ")
-                .append(formattedDisplayName));
+        Assertions.assertEquals("You've been joined to "+displayName, getPlainText(player.nextComponentMessage()));
         return player;
     }
     
     void addTeam(String teamName, String teamDisplayName, String teamColor) {
-        plugin.getMctCommand().onCommand(sender, command, "mct", new String[]{"team", "add", teamName, teamDisplayName, teamColor});
-    }
-    
-    Component formatTeamDisplayName(String displayName, NamedTextColor teamColor) {
-        return Component.text(displayName).color(teamColor).decorate(TextDecoration.BOLD);
+        plugin.getMctCommand().onCommand(sender, command, "mct", new String[]{"team", "add", teamName, String.format("\"%s\"", teamDisplayName), teamColor});
     }
     
     String getPlainText(Component component) {
@@ -108,12 +102,12 @@ public class CaptureTheFlagTest {
     @DisplayName("With 3 teams, the third team gets notified they're on deck")
     void threePlayerOnDeckTest() {
         try {
-            addTeam("red", "\"Red\"", "red");
-            addTeam("blue", "\"Blue\"", "blue");
-            addTeam("green", "\"Green\"", "green");
-            PlayerMock player1 = createParticipant("Player1", "red", "Red", NamedTextColor.RED);
-            PlayerMock player2 = createParticipant("Player2", "blue", "Blue", NamedTextColor.BLUE);
-            PlayerMock player3 = createParticipant("Player3", "green", "Green", NamedTextColor.GREEN);
+            addTeam("red", "Red", "red");
+            addTeam("blue", "Blue", "blue");
+            addTeam("green", "Green", "green");
+            PlayerMock player1 = createParticipant("Player1", "red", "Red");
+            PlayerMock player2 = createParticipant("Player2", "blue", "Blue");
+            PlayerMock player3 = createParticipant("Player3", "green", "Green");
             plugin.getMctCommand().onCommand(sender, command, "mct", new String[]{"game", "start", "capture-the-flag"});
             
             Assertions.assertEquals("Red is competing against Blue this round.", getPlainText(player1.nextComponentMessage()));

--- a/src/test/java/org/braekpo1nt/mctmanager/games/capturetheflag/CaptureTheFlagTest.java
+++ b/src/test/java/org/braekpo1nt/mctmanager/games/capturetheflag/CaptureTheFlagTest.java
@@ -3,9 +3,6 @@ package org.braekpo1nt.mctmanager.games.capturetheflag;
 import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.UnimplementedOperationException;
-import be.seeseemelk.mockbukkit.entity.PlayerMock;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.TextComponent;
 import org.braekpo1nt.mctmanager.Main;
 import org.braekpo1nt.mctmanager.MyCustomServerMock;
 import org.braekpo1nt.mctmanager.MyPlayerMock;
@@ -54,8 +51,8 @@ public class CaptureTheFlagTest {
         try {
             addTeam("red", "Red", "red");
             addTeam("blue", "Blue", "blue");
-            PlayerMock player1 = createParticipant("Player1", "red", "Red");
-            PlayerMock player2 = createParticipant("Player2", "blue", "Blue");
+            createParticipant("Player1", "red", "Red");
+            createParticipant("Player2", "blue", "Blue");
             plugin.getMctCommand().onCommand(sender, command, "mct", new String[]{"game", "start", "capture-the-flag"});
             server.getScheduler().performTicks((20 * 10) + 1); // speed through the startMatchesStartingCountDown()
             server.getScheduler().performTicks((20 * 20) + 1); // speed through the startClassSelectionPeriod()
@@ -70,36 +67,16 @@ public class CaptureTheFlagTest {
         }
     }
     
-    PlayerMock createParticipant(String name, String teamName, String displayName) {
-        PlayerMock player = new MyPlayerMock(server, name);
+    MyPlayerMock createParticipant(String name, String teamName, String displayName) {
+        MyPlayerMock player = new MyPlayerMock(server, name);
         server.addPlayer(player);
         plugin.getMctCommand().onCommand(sender, command, "mct", new String[]{"team", "join", teamName, player.getName()});
-        Assertions.assertEquals("You've been joined to "+displayName, toPlainText(player.nextComponentMessage()));
+        player.assertSaidPlaintext("You've been joined to "+displayName);
         return player;
     }
     
     void addTeam(String teamName, String teamDisplayName, String teamColor) {
         plugin.getMctCommand().onCommand(sender, command, "mct", new String[]{"team", "add", teamName, String.format("\"%s\"", teamDisplayName), teamColor});
-    }
-    
-    /**
-     * Takes in a Component with 1 or more children, and converts it to a plaintext string without formatting.
-     * Assumes it is made up of TextComponents and empty components.
-     * @param component The component to get the plaintext version of
-     * @return The concatenation of the contents() of the TextComponent children that this component is made of
-     */
-    String toPlainText(Component component) {
-        StringBuilder builder = new StringBuilder();
-        
-        if (component instanceof TextComponent textComponent) {
-            builder.append(textComponent.content());
-        }
-        
-        for (Component child : component.children()) {
-            builder.append(toPlainText(child));
-        }
-        
-        return builder.toString();
     }
     
     @Test
@@ -109,14 +86,14 @@ public class CaptureTheFlagTest {
             addTeam("red", "Red", "red");
             addTeam("blue", "Blue", "blue");
             addTeam("green", "Green", "green");
-            PlayerMock player1 = createParticipant("Player1", "red", "Red");
-            PlayerMock player2 = createParticipant("Player2", "blue", "Blue");
-            PlayerMock player3 = createParticipant("Player3", "green", "Green");
+            MyPlayerMock player1 = createParticipant("Player1", "red", "Red");
+            MyPlayerMock player2 = createParticipant("Player2", "blue", "Blue");
+            MyPlayerMock player3 = createParticipant("Player3", "green", "Green");
             plugin.getMctCommand().onCommand(sender, command, "mct", new String[]{"game", "start", "capture-the-flag"});
             
-            Assertions.assertEquals("Red is competing against Blue this round.", toPlainText(player1.nextComponentMessage()));
-            Assertions.assertEquals("Blue is competing against Red this round.", toPlainText(player2.nextComponentMessage()));
-            Assertions.assertEquals("Green is not competing in this round. Their next round is 1", toPlainText(player3.nextComponentMessage()));
+            player1.assertSaidPlaintext("Red is competing against Blue this round.");
+            player2.assertSaidPlaintext("Blue is competing against Red this round.");
+            player3.assertSaidPlaintext("Green is not competing in this round. Their next round is 1");
         } catch (UnimplementedOperationException ex) {
             System.out.println("UnimplementedOperationException in threePlayerOnDeckTest()");
             ex.printStackTrace();

--- a/src/test/java/org/braekpo1nt/mctmanager/games/capturetheflag/CaptureTheFlagTest.java
+++ b/src/test/java/org/braekpo1nt/mctmanager/games/capturetheflag/CaptureTheFlagTest.java
@@ -7,6 +7,7 @@ import org.braekpo1nt.mctmanager.Main;
 import org.braekpo1nt.mctmanager.MyCustomServerMock;
 import org.braekpo1nt.mctmanager.MyPlayerMock;
 import org.braekpo1nt.mctmanager.ui.FastBoardManager;
+import org.braekpo1nt.mctmanager.ui.MockFastBoardManager;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.PluginCommand;
 import org.junit.jupiter.api.*;
@@ -34,7 +35,8 @@ public class CaptureTheFlagTest {
             ex.printStackTrace();
             System.exit(1);
         }
-        FastBoardManager mockFastBoardManager = mock(FastBoardManager.class, RETURNS_DEFAULTS);
+//        FastBoardManager mockFastBoardManager = mock(FastBoardManager.class, RETURNS_DEFAULTS);
+        FastBoardManager mockFastBoardManager = new MockFastBoardManager();
         plugin.setFastBoardManager(mockFastBoardManager);
         command = plugin.getCommand("mct");
         sender = server.getConsoleSender();

--- a/src/test/java/org/braekpo1nt/mctmanager/games/capturetheflag/CaptureTheFlagTest.java
+++ b/src/test/java/org/braekpo1nt/mctmanager/games/capturetheflag/CaptureTheFlagTest.java
@@ -6,8 +6,6 @@ import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 import be.seeseemelk.mockbukkit.entity.PlayerMock;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
-import net.kyori.adventure.text.format.NamedTextColor;
-import net.kyori.adventure.text.format.TextDecoration;
 import org.braekpo1nt.mctmanager.Main;
 import org.braekpo1nt.mctmanager.MyCustomServerMock;
 import org.braekpo1nt.mctmanager.MyPlayerMock;
@@ -51,24 +49,24 @@ public class CaptureTheFlagTest {
     }
     
     @Test
+    @DisplayName("Starting capture the flag with two players has no errors up to the class selection period")
     void twoPlayersGetToMatchStart() {
         try {
-            PlayerMock player1 = new MyPlayerMock(server, "Player1");
-            server.addPlayer(player1);
-            PlayerMock player2 = new MyPlayerMock(server, "Player2");
-            server.addPlayer(player2);
-            plugin.getMctCommand().onCommand(sender, command, "mct", new String[]{"team", "add", "red", "\"Red\"", "red"});
-            plugin.getMctCommand().onCommand(sender, command, "mct", new String[]{"team", "add", "blue", "\"Blue\"", "blue"});
-            plugin.getMctCommand().onCommand(sender, command, "mct", new String[]{"team", "join", "red", player1.getName()});
-            plugin.getMctCommand().onCommand(sender, command, "mct", new String[]{"team", "join", "blue", player2.getName()});
+            addTeam("red", "Red", "red");
+            addTeam("blue", "Blue", "blue");
+            PlayerMock player1 = createParticipant("Player1", "red", "Red");
+            PlayerMock player2 = createParticipant("Player2", "blue", "Blue");
             plugin.getMctCommand().onCommand(sender, command, "mct", new String[]{"game", "start", "capture-the-flag"});
             server.getScheduler().performTicks((20 * 10) + 1); // speed through the startMatchesStartingCountDown()
             server.getScheduler().performTicks((20 * 20) + 1); // speed through the startClassSelectionPeriod()
             
         } catch (UnimplementedOperationException ex) {
-            System.out.println("UnimplementedOperationException in startGame()");
+            System.out.println("UnimplementedOperationException in twoPlayersGetToMatchStart()");
             ex.printStackTrace();
-            System.exit(1);
+            Assertions.fail(ex.getMessage());
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            Assertions.fail(ex.getMessage());
         }
     }
     
@@ -76,7 +74,7 @@ public class CaptureTheFlagTest {
         PlayerMock player = new MyPlayerMock(server, name);
         server.addPlayer(player);
         plugin.getMctCommand().onCommand(sender, command, "mct", new String[]{"team", "join", teamName, player.getName()});
-        Assertions.assertEquals("You've been joined to "+displayName, getPlainText(player.nextComponentMessage()));
+        Assertions.assertEquals("You've been joined to "+displayName, toPlainText(player.nextComponentMessage()));
         return player;
     }
     
@@ -84,7 +82,13 @@ public class CaptureTheFlagTest {
         plugin.getMctCommand().onCommand(sender, command, "mct", new String[]{"team", "add", teamName, String.format("\"%s\"", teamDisplayName), teamColor});
     }
     
-    String getPlainText(Component component) {
+    /**
+     * Takes in a Component with 1 or more children, and converts it to a plaintext string without formatting.
+     * Assumes it is made up of TextComponents and empty components.
+     * @param component The component to get the plaintext version of
+     * @return The concatenation of the contents() of the TextComponent children that this component is made of
+     */
+    String toPlainText(Component component) {
         StringBuilder builder = new StringBuilder();
         
         if (component instanceof TextComponent textComponent) {
@@ -92,7 +96,7 @@ public class CaptureTheFlagTest {
         }
         
         for (Component child : component.children()) {
-            builder.append(getPlainText(child));
+            builder.append(toPlainText(child));
         }
         
         return builder.toString();
@@ -110,16 +114,16 @@ public class CaptureTheFlagTest {
             PlayerMock player3 = createParticipant("Player3", "green", "Green");
             plugin.getMctCommand().onCommand(sender, command, "mct", new String[]{"game", "start", "capture-the-flag"});
             
-            Assertions.assertEquals("Red is competing against Blue this round.", getPlainText(player1.nextComponentMessage()));
-            Assertions.assertEquals("Blue is competing against Red this round.", getPlainText(player2.nextComponentMessage()));
-            Assertions.assertEquals("Green is not competing in this round. Their next round is 1", getPlainText(player3.nextComponentMessage()));
+            Assertions.assertEquals("Red is competing against Blue this round.", toPlainText(player1.nextComponentMessage()));
+            Assertions.assertEquals("Blue is competing against Red this round.", toPlainText(player2.nextComponentMessage()));
+            Assertions.assertEquals("Green is not competing in this round. Their next round is 1", toPlainText(player3.nextComponentMessage()));
         } catch (UnimplementedOperationException ex) {
-            System.out.println("UnimplementedOperationException in startGame()");
+            System.out.println("UnimplementedOperationException in threePlayerOnDeckTest()");
             ex.printStackTrace();
             Assertions.fail(ex.getMessage());
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assertions.fail(e.getMessage());
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            Assertions.fail(ex.getMessage());
         }
     }
     

--- a/src/test/java/org/braekpo1nt/mctmanager/games/capturetheflag/CaptureTheFlagTest.java
+++ b/src/test/java/org/braekpo1nt/mctmanager/games/capturetheflag/CaptureTheFlagTest.java
@@ -90,6 +90,19 @@ public class CaptureTheFlagTest {
         return Component.text(displayName).color(teamColor).decorate(TextDecoration.BOLD);
     }
     
+    String getPlainText(Component component) {
+        StringBuilder builder = new StringBuilder();
+        
+        if (component instanceof TextComponent textComponent) {
+            builder.append(textComponent.content());
+        }
+        
+        for (Component child : component.children()) {
+            builder.append(getPlainText(child));
+        }
+        
+        return builder.toString();
+    }
     
     @Test
     @DisplayName("With 3 teams, the third team gets notified they're on deck")
@@ -103,11 +116,9 @@ public class CaptureTheFlagTest {
             PlayerMock player3 = createParticipant("Player3", "green", "Green", NamedTextColor.GREEN);
             plugin.getMctCommand().onCommand(sender, command, "mct", new String[]{"game", "start", "capture-the-flag"});
             
-            player1.assertSaid("Red is competing against Blue this round.");
-            player2.assertSaid("Blue is competing against Red this round.");
-            player3.assertSaid("Green is not competing in this round. Their next round is 1");
-            
-            Assertions.assertTrue(true);
+            Assertions.assertEquals("Red is competing against Blue this round.", getPlainText(player1.nextComponentMessage()));
+            Assertions.assertEquals("Blue is competing against Red this round.", getPlainText(player2.nextComponentMessage()));
+            Assertions.assertEquals("Green is not competing in this round. Their next round is 1", getPlainText(player3.nextComponentMessage()));
         } catch (UnimplementedOperationException ex) {
             System.out.println("UnimplementedOperationException in startGame()");
             ex.printStackTrace();

--- a/src/test/java/org/braekpo1nt/mctmanager/games/capturetheflag/CaptureTheFlagTest.java
+++ b/src/test/java/org/braekpo1nt/mctmanager/games/capturetheflag/CaptureTheFlagTest.java
@@ -22,6 +22,7 @@ public class CaptureTheFlagTest {
     private Main plugin;
     private PluginCommand command;
     private CommandSender sender;
+    private MockFastBoardManager mockFastBoardManager;
     
     
     @BeforeEach
@@ -36,7 +37,7 @@ public class CaptureTheFlagTest {
             System.exit(1);
         }
 //        FastBoardManager mockFastBoardManager = mock(FastBoardManager.class, RETURNS_DEFAULTS);
-        FastBoardManager mockFastBoardManager = new MockFastBoardManager();
+        mockFastBoardManager = new MockFastBoardManager();
         plugin.setFastBoardManager(mockFastBoardManager);
         command = plugin.getCommand("mct");
         sender = server.getConsoleSender();
@@ -96,6 +97,7 @@ public class CaptureTheFlagTest {
             player1.assertSaidPlaintext("Red is competing against Blue this round.");
             player2.assertSaidPlaintext("Blue is competing against Red this round.");
             player3.assertSaidPlaintext("Green is not competing in this round. Their next round is 1");
+            mockFastBoardManager.assertLine(player3.getUniqueId(), 1, "On Deck");
         } catch (UnimplementedOperationException ex) {
             System.out.println("UnimplementedOperationException in threePlayerOnDeckTest()");
             ex.printStackTrace();

--- a/src/test/java/org/braekpo1nt/mctmanager/ui/MockFastBoard.java
+++ b/src/test/java/org/braekpo1nt/mctmanager/ui/MockFastBoard.java
@@ -1,0 +1,24 @@
+package org.braekpo1nt.mctmanager.ui;
+
+public class MockFastBoard {
+    
+    public void updateLine(int line, String text) {
+        
+    }
+    
+    public void updateTitle(String title) {
+        
+    }
+    
+    public void updateLines(String... lines) {
+        
+    }
+    
+    public boolean isDeleted() {
+        return false;
+    }
+    
+    public void delete() {
+        
+    }
+}

--- a/src/test/java/org/braekpo1nt/mctmanager/ui/MockFastBoard.java
+++ b/src/test/java/org/braekpo1nt/mctmanager/ui/MockFastBoard.java
@@ -27,4 +27,8 @@ public class MockFastBoard {
     public String[] getLines() {
         return lines;
     }
+    
+    public String getLine(int line) {
+        return lines[line];
+    }
 }

--- a/src/test/java/org/braekpo1nt/mctmanager/ui/MockFastBoard.java
+++ b/src/test/java/org/braekpo1nt/mctmanager/ui/MockFastBoard.java
@@ -2,8 +2,10 @@ package org.braekpo1nt.mctmanager.ui;
 
 public class MockFastBoard {
     
+    private String[] lines;
+    
     public void updateLine(int line, String text) {
-        
+        this.lines[line] = text;
     }
     
     public void updateTitle(String title) {
@@ -11,7 +13,7 @@ public class MockFastBoard {
     }
     
     public void updateLines(String... lines) {
-        
+        this.lines = lines;
     }
     
     public boolean isDeleted() {
@@ -19,6 +21,10 @@ public class MockFastBoard {
     }
     
     public void delete() {
-        
+        this.lines = null;
+    }
+    
+    public String[] getLines() {
+        return lines;
     }
 }

--- a/src/test/java/org/braekpo1nt/mctmanager/ui/MockFastBoardManager.java
+++ b/src/test/java/org/braekpo1nt/mctmanager/ui/MockFastBoardManager.java
@@ -3,6 +3,7 @@ package org.braekpo1nt.mctmanager.ui;
 import org.bukkit.entity.Player;
 import org.junit.jupiter.api.Assertions;
 
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.UUID;
@@ -110,6 +111,14 @@ public class MockFastBoardManager extends FastBoardManager {
         MockFastBoard board = boards.get(playerUniqueId);
         Assertions.assertNotNull(board);
         String[] lines = board.getLines();
-        Assertions.assertEquals(expectedLines, lines);
+        Assertions.assertEquals(expectedLines, Arrays.copyOfRange(lines, 2, lines.length));
+    }
+    
+    public void assertLine(UUID playerUniqueId, int line, String expectedText) {
+        MockFastBoard board = boards.get(playerUniqueId);
+        Assertions.assertNotNull(board);
+        int subLine = line + 2;
+        String text = board.getLine(subLine);
+        Assertions.assertEquals(expectedText, text);
     }
 }

--- a/src/test/java/org/braekpo1nt/mctmanager/ui/MockFastBoardManager.java
+++ b/src/test/java/org/braekpo1nt/mctmanager/ui/MockFastBoardManager.java
@@ -1,7 +1,7 @@
 package org.braekpo1nt.mctmanager.ui;
 
-import org.braekpo1nt.mctmanager.games.gamestate.GameStateStorageUtil;
 import org.bukkit.entity.Player;
+import org.junit.jupiter.api.Assertions;
 
 import java.util.Iterator;
 import java.util.Map;
@@ -104,5 +104,12 @@ public class MockFastBoardManager extends FastBoardManager {
             }
             iterator.remove();
         }
+    }
+    
+    public void assertLines(UUID playerUniqueId, String... expectedLines) {
+        MockFastBoard board = boards.get(playerUniqueId);
+        Assertions.assertNotNull(board);
+        String[] lines = board.getLines();
+        Assertions.assertEquals(expectedLines, lines);
     }
 }

--- a/src/test/java/org/braekpo1nt/mctmanager/ui/MockFastBoardManager.java
+++ b/src/test/java/org/braekpo1nt/mctmanager/ui/MockFastBoardManager.java
@@ -1,0 +1,61 @@
+package org.braekpo1nt.mctmanager.ui;
+
+import org.bukkit.entity.Player;
+
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class MockFastBoardManager extends FastBoardManager {
+    
+    private final ConcurrentHashMap<UUID, String[]> boards = new ConcurrentHashMap<>();
+    
+    public MockFastBoardManager() {
+        super(null);
+    }
+    
+    @Override
+    protected synchronized void updateMainBoardForPlayer(Player player) {
+//        boolean playerHasBoard = givePlayerBoardIfAbsent(player);
+//        if (!playerHasBoard) {
+//            return;
+//        }
+//        UUID playerUniqueId = player.getUniqueId();
+//        String[] board = boards.get(playerUniqueId);
+        
+    }
+    
+    @Override
+    protected synchronized boolean givePlayerBoardIfAbsent(Player player) {
+        return false;
+    }
+    
+    @Override
+    protected synchronized void addBoard(Player player) {
+        
+    }
+    
+    @Override
+    protected String[] getMainLines(UUID playerUniqueId) {
+        return null;
+    }
+    
+    @Override
+    public synchronized void updateLines(UUID playerUniqueId, String... lines) {
+        
+    }
+    
+    @Override
+    public synchronized void updateLine(UUID playerUniqueId, int line, String text) {
+        
+    }
+    
+    @Override
+    public synchronized void removeBoard(UUID playerUniqueId) {
+        
+    }
+    
+    @Override
+    public synchronized void removeAllBoards() {
+        
+    }
+}

--- a/src/test/java/org/braekpo1nt/mctmanager/ui/MockFastBoardManager.java
+++ b/src/test/java/org/braekpo1nt/mctmanager/ui/MockFastBoardManager.java
@@ -1,13 +1,16 @@
 package org.braekpo1nt.mctmanager.ui;
 
+import org.braekpo1nt.mctmanager.games.gamestate.GameStateStorageUtil;
 import org.bukkit.entity.Player;
 
+import java.util.Iterator;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class MockFastBoardManager extends FastBoardManager {
     
-    private final ConcurrentHashMap<UUID, String[]> boards = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<UUID, MockFastBoard> boards = new ConcurrentHashMap<>();
     
     public MockFastBoardManager() {
         super(null);
@@ -15,47 +18,91 @@ public class MockFastBoardManager extends FastBoardManager {
     
     @Override
     protected synchronized void updateMainBoardForPlayer(Player player) {
-//        boolean playerHasBoard = givePlayerBoardIfAbsent(player);
-//        if (!playerHasBoard) {
-//            return;
-//        }
-//        UUID playerUniqueId = player.getUniqueId();
-//        String[] board = boards.get(playerUniqueId);
-        
+        boolean playerHasBoard = givePlayerBoardIfAbsent(player);
+        if (!playerHasBoard) {
+            return;
+        }
+        UUID playerUniqueId = player.getUniqueId();
+        MockFastBoard board = boards.get(playerUniqueId);
+        String[] mainLines = getMainLines(playerUniqueId);
+        String teamLine = mainLines[0];
+        String scoreLine = mainLines[1];
+        board.updateLine(0, teamLine);
+        board.updateLine(1, scoreLine);
     }
     
     @Override
     protected synchronized boolean givePlayerBoardIfAbsent(Player player) {
+        UUID playerUniqueId = player.getUniqueId();
+        if (boards.containsKey(playerUniqueId)) {
+            return true;
+        }
+        if (gameStateStorageUtil.containsPlayer(playerUniqueId)) {
+            addBoard(player);
+            return true;
+        }
         return false;
     }
     
     @Override
     protected synchronized void addBoard(Player player) {
-        
-    }
-    
-    @Override
-    protected String[] getMainLines(UUID playerUniqueId) {
-        return null;
+        MockFastBoard newBoard = new MockFastBoard();
+        newBoard.updateTitle(this.EVENT_TITLE);
+        String[] mainLines = getMainLines(player.getUniqueId());
+        String teamLine = mainLines[0];
+        String scoreLine = mainLines[1];
+        newBoard.updateLines(
+                teamLine,
+                scoreLine
+        );
+        boards.put(player.getUniqueId(), newBoard);
     }
     
     @Override
     public synchronized void updateLines(UUID playerUniqueId, String... lines) {
-        
+        if (!boards.containsKey(playerUniqueId)) {
+            return;
+        }
+        MockFastBoard board = boards.get(playerUniqueId);
+        String[] mainLines = getMainLines(playerUniqueId);
+        String[] linesPlusMainLines = new String[lines.length + 2];
+        linesPlusMainLines[0] = mainLines[0];
+        linesPlusMainLines[1] = mainLines[1];
+        System.arraycopy(lines, 0, linesPlusMainLines, 2, lines.length);
+        board.updateLines(linesPlusMainLines);
     }
     
     @Override
     public synchronized void updateLine(UUID playerUniqueId, int line, String text) {
-        
+        if (!boards.containsKey(playerUniqueId)) {
+            return;
+        }
+        MockFastBoard board = boards.get(playerUniqueId);
+        int subLine = line + 2;
+        board.updateLine(subLine, text);
     }
     
     @Override
     public synchronized void removeBoard(UUID playerUniqueId) {
-        
+        if (!boards.containsKey(playerUniqueId)) {
+            return;
+        }
+        MockFastBoard board = boards.get(playerUniqueId);
+        if (board != null && !board.isDeleted()) {
+            board.delete();
+        }
     }
     
     @Override
     public synchronized void removeAllBoards() {
-        
+        Iterator<Map.Entry<UUID, MockFastBoard>> iterator = boards.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<UUID, MockFastBoard> entry = iterator.next();
+            MockFastBoard board = entry.getValue();
+            if (!board.isDeleted()) {
+                board.delete();
+            }
+            iterator.remove();
+        }
     }
 }


### PR DESCRIPTION
## Changes
- Made it notify the participants who are on deck, both in chat and on the sidebar
- Made it notify players in the current round who they're fighting in the chat 
- Rounds treat players and on deck players differently

## Test changes
- Made FastBoardManager mockable
- Created mock FastBoardManager and mock FastBoard to allow for verification of fastboard contents
- Allowed for checking the message sent to a Mocked player in chat using plaintext, so you don't have to worry about formatting
- 