### PR TITLE
395 change number of games mid event

### DIFF
--- a/src/main/java/org/braekpo1nt/mctmanager/Main.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/Main.java
@@ -79,6 +79,12 @@ public class Main extends JavaPlugin {
             gameManager.cancelVote();
             gameManager.cancelAllTasks();
             gameManager.saveGameState();
+            if (gameManager.getEventManager().eventIsActive()) {
+                gameManager.getEventManager().stopEvent(Bukkit.getConsoleSender());
+            }
+            if (gameManager.getEventManager().colossalCombatIsActive()) {
+                gameManager.getEventManager().stopColossalCombat(Bukkit.getConsoleSender());
+            }
             if (gameManager.gameIsRunning()) {
                 gameManager.manuallyStopGame(false);
             }

--- a/src/main/java/org/braekpo1nt/mctmanager/commands/event/EventSubCommand.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/commands/event/EventSubCommand.java
@@ -48,33 +48,41 @@ public class EventSubCommand extends CommandManager {
                 return Collections.emptyList();
             }
         });
-        subCommands.put("stop", (sender, command, label, args) -> {
-            if (!gameManager.getEventManager().eventIsActive()) {
-                sender.sendMessage(Component.text("There is no event running.")
-                        .color(NamedTextColor.RED));
+        subCommands.put("stop", new TabExecutor() {
+            @Override
+            public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+                if (!gameManager.getEventManager().eventIsActive()) {
+                    sender.sendMessage(Component.text("There is no event running.")
+                            .color(NamedTextColor.RED));
+                    return true;
+                }
+                if (args.length != 1) {
+                    sender.sendMessage(Component.text("Are you sure? Type ")
+                            .append(Component.empty()
+                                    .append(Component.text("/mct event stop "))
+                                    .append(Component.text("confirm")
+                                            .decorate(TextDecoration.BOLD))
+                                    .decorate(TextDecoration.ITALIC))
+                            .append(Component.text(" to confirm."))
+                            .color(NamedTextColor.YELLOW));
+                    return true;
+                }
+                String confirmString = args[0];
+                if (!confirmString.equals("confirm")) {
+                    sender.sendMessage(Component.empty()
+                            .append(Component.text(confirmString))
+                            .append(Component.text(" is not a recognized option."))
+                            .color(NamedTextColor.RED));
+                    return true;
+                }
+                gameManager.getEventManager().stopEvent(sender);
                 return true;
             }
-            if (args.length != 1) {
-                sender.sendMessage(Component.text("Are you sure? Type ")
-                        .append(Component.empty()
-                                .append(Component.text("/mct event stop "))
-                                .append(Component.text("confirm")
-                                        .decorate(TextDecoration.BOLD))
-                                .decorate(TextDecoration.ITALIC))
-                        .append(Component.text(" to confirm."))
-                        .color(NamedTextColor.YELLOW));
-                return true;
+            
+            @Override
+            public List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+                    return Collections.emptyList();
             }
-            String confirmString = args[0];
-            if (!confirmString.equals("confirm")) {
-                sender.sendMessage(Component.empty()
-                        .append(Component.text(confirmString))
-                        .append(Component.text(" is not a recognized option."))
-                        .color(NamedTextColor.RED));
-                return true;
-            }
-            gameManager.getEventManager().stopEvent(sender);
-            return true;
         });
         subCommands.put("pause", (sender, command, label, args) -> {
             gameManager.getEventManager().pauseEvent(sender);

--- a/src/main/java/org/braekpo1nt/mctmanager/commands/event/EventSubCommand.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/commands/event/EventSubCommand.java
@@ -13,6 +13,7 @@ import org.bukkit.command.TabExecutor;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -115,10 +116,35 @@ public class EventSubCommand extends CommandManager {
             
             @Override
             public List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
-                return Collections.emptyList();
+                if (args.length != 2) {
+                    return Collections.emptyList();
+                }
+                String gameID = args[0];
+                GameType gameType = GameType.fromID(gameID);
+                if (gameType == null) {
+                    return Collections.emptyList();
+                }
+                int iterations = gameManager.getEventManager().getGameIterations(gameType);
+                if (iterations <= 0) {
+                    return Collections.emptyList();
+                }
+                return generateNumberList(iterations);
             }
         });
         subCommands.put("vote", new VoteSubCommand(gameManager));
+    }
+    
+    /**
+     * 
+     * @param n the number to generate numbers up to (must be at least 1 to get any entries)
+     * @return a list containing the numbers 1 through n inclusive as Strings, in increasing order. If n is less than 1, an empty list is produced. 
+     */
+    public static List<String> generateNumberList(int n) {
+        List<String> numbers = new ArrayList<>();
+        for (int i = 1; i <= n; i++) {
+            numbers.add(Integer.toString(i));
+        }
+        return numbers;
     }
     
     @Override

--- a/src/main/java/org/braekpo1nt/mctmanager/commands/event/EventSubCommand.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/commands/event/EventSubCommand.java
@@ -11,7 +11,6 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabExecutor;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -140,6 +139,7 @@ public class EventSubCommand extends CommandManager {
             }
         });
         subCommands.put("vote", new VoteSubCommand(gameManager));
+        subCommands.put("modify", new ModifySubCommand(gameManager));
     }
     
     /**
@@ -159,5 +159,5 @@ public class EventSubCommand extends CommandManager {
     public Component getUsageMessage() {
         return Component.text("Usage: /mct event <options>");
     }
-       
+    
 }

--- a/src/main/java/org/braekpo1nt/mctmanager/commands/event/ModifySubCommand.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/commands/event/ModifySubCommand.java
@@ -1,0 +1,60 @@
+package org.braekpo1nt.mctmanager.commands.event;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.braekpo1nt.mctmanager.commands.CommandManager;
+import org.braekpo1nt.mctmanager.commands.CommandUtils;
+import org.braekpo1nt.mctmanager.games.GameManager;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabExecutor;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+import java.util.List;
+
+class ModifySubCommand extends CommandManager {
+    
+    public ModifySubCommand(GameManager gameManager) {
+        subCommands.put("maxgames", new TabExecutor() {
+            @Override
+            public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+                if (!gameManager.getEventManager().eventIsActive()) {
+                    sender.sendMessage(Component.text("There is no event running.")
+                            .color(NamedTextColor.RED));
+                    return true;
+                }
+                
+                if (args.length != 1) {
+                    sender.sendMessage(Component.text("Usage: /mct event maxgames <new count>")
+                            .color(NamedTextColor.RED));
+                    return true;
+                }
+                
+                String newCountString = args[0];
+                if (!CommandUtils.isInteger(newCountString)) {
+                    sender.sendMessage(Component.text(newCountString)
+                            .append(Component.text(" is not a valid integer"))
+                            .color(NamedTextColor.RED));
+                    return true;
+                }
+                
+                int newCount = Integer.parseInt(newCountString);
+                gameManager.getEventManager().setMaxGames(sender, newCount);
+                
+                return true;
+            }
+            
+            @Override
+            public List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+                return Collections.emptyList();
+            }
+        });
+    }
+    
+    @Override
+    public Component getUsageMessage() {
+        return Component.text("Usage: /mct event modify <options>");
+    }
+       
+}

--- a/src/main/java/org/braekpo1nt/mctmanager/games/GameManager.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/GameManager.java
@@ -431,6 +431,14 @@ public class GameManager implements Listener {
         hubManager.returnParticipantsToHub(onlineParticipants, onlineAdmins, false);
     }
     
+    /**
+     * Instantly returns the given participant to the hub
+     * @param participant the participant to be returned to the hub
+     */
+    public void returnParticipantToHubInstantly(Player participant) {
+        hubManager.returnParticipantsToHub(Collections.singletonList(participant), Collections.emptyList(), false);
+    }
+    
     public void returnAllParticipantsToPodium(String winningTeam) {
         List<Player> winningTeamParticipants = getOnlinePlayersOnTeam(winningTeam);
         List<Player> otherParticipants = new ArrayList<>();

--- a/src/main/java/org/braekpo1nt/mctmanager/games/event/EventManager.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/event/EventManager.java
@@ -436,6 +436,12 @@ public class EventManager implements Listener {
             return;
         }
         EventState state = currentState == EventState.PAUSED ? lastStateBeforePause : currentState;
+        // make sure the participant isn't stuck in whatever location they last logged out from, if they aren't supposed to be
+        switch (state) {
+            case WAITING_IN_HUB, VOTING, PODIUM -> {
+                gameManager.returnParticipantToHubInstantly(participant);
+            }
+        }
         switch (state) {
             case DELAY, WAITING_IN_HUB, PODIUM -> {
                 participants.add(participant);

--- a/src/main/java/org/braekpo1nt/mctmanager/games/event/EventManager.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/event/EventManager.java
@@ -595,9 +595,15 @@ public class EventManager implements Listener {
                 if (count <= 0) {
                     currentState = EventState.PODIUM;
                     sidebar.addLine("winner", String.format("%sWinner: %s", winningChatColor, winningDisplayName));
-                    sidebar.updateLine("timer", "");
+                    sidebar.updateLines(
+                            new KeyLine("currentGame", getCurrentGameLine()),
+                            new KeyLine("timer", "")
+                    );
                     adminSidebar.addLine("winner", String.format("%sWinner: %s", winningChatColor, winningDisplayName));
-                    adminSidebar.updateLine("timer", "");
+                    adminSidebar.updateLines(
+                            new KeyLine("currentGame", getCurrentGameLine()),
+                            new KeyLine("timer", "")
+                    );
                     gameManager.returnAllParticipantsToPodium(winningTeam);
                     this.cancel();
                     return;

--- a/src/main/java/org/braekpo1nt/mctmanager/games/event/EventManager.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/event/EventManager.java
@@ -163,12 +163,8 @@ public class EventManager implements Listener {
                     .color(NamedTextColor.RED));
             return;
         }
-        if (currentState == EventState.PLAYING_GAME) {
-            sender.sendMessage(Component.text("Can't stop the event mid-game.")
-                    .color(NamedTextColor.RED));
-            return;
-        }
         HandlerList.unregisterAll(this);
+        currentState = null;
         Component message = Component.text("Ending event. ")
                 .append(Component.text(currentGameNumber - 1))
                 .append(Component.text("/"))
@@ -181,9 +177,9 @@ public class EventManager implements Listener {
             colossalCombatGame.stop(null);
         }
         clearSidebar();
-        admins.clear();
         clearAdminSidebar();
-        currentState = null;
+        participants.clear();
+        admins.clear();
         cancelAllTasks();
         scoreKeepers.clear();
         currentGameNumber = 0;
@@ -981,8 +977,9 @@ public class EventManager implements Listener {
         if (!participants.contains(participant)) {
             return;
         }
-        if (currentState.equals(EventState.DELAY)) {
-            event.setCancelled(true);
+        switch (currentState) {
+            case WAITING_IN_HUB, VOTING, DELAY, PAUSED, PODIUM 
+                    -> event.setCancelled(true);
         }
     }
     

--- a/src/main/java/org/braekpo1nt/mctmanager/games/game/capturetheflag/CaptureTheFlagMatch.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/game/capturetheflag/CaptureTheFlagMatch.java
@@ -696,8 +696,8 @@ public class CaptureTheFlagMatch implements Listener {
     }
     
     public void startClassSelectionPeriod() {
-        northClassPicker.start(plugin, northParticipants, storageUtil.getLoadouts());
-        southClassPicker.start(plugin, southParticipants, storageUtil.getLoadouts());
+        northClassPicker.start(plugin, northParticipants, storageUtil.getMenuItems(), storageUtil.getMenuLores(), storageUtil.getLoadouts());
+        southClassPicker.start(plugin, southParticipants, storageUtil.getMenuItems(), storageUtil.getMenuLores(), storageUtil.getLoadouts());
         
         this.classSelectionCountdownTaskId = new BukkitRunnable() {
             private int count = storageUtil.getClassSelectionDuration();

--- a/src/main/java/org/braekpo1nt/mctmanager/games/game/capturetheflag/CaptureTheFlagMatch.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/game/capturetheflag/CaptureTheFlagMatch.java
@@ -696,8 +696,8 @@ public class CaptureTheFlagMatch implements Listener {
     }
     
     public void startClassSelectionPeriod() {
-        northClassPicker.start(plugin, northParticipants, storageUtil.getMenuItems(), storageUtil.getMenuLores(), storageUtil.getLoadouts());
-        southClassPicker.start(plugin, southParticipants, storageUtil.getMenuItems(), storageUtil.getMenuLores(), storageUtil.getLoadouts());
+        northClassPicker.start(plugin, northParticipants, storageUtil.getLoadouts());
+        southClassPicker.start(plugin, southParticipants, storageUtil.getLoadouts());
         
         this.classSelectionCountdownTaskId = new BukkitRunnable() {
             private int count = storageUtil.getClassSelectionDuration();

--- a/src/main/java/org/braekpo1nt/mctmanager/games/game/capturetheflag/ClassPicker.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/game/capturetheflag/ClassPicker.java
@@ -34,31 +34,23 @@ public class ClassPicker implements Listener {
     private final Map<UUID, BattleClass> pickedBattleClasses = new HashMap<>();
     private final List<Player> teamMates = new ArrayList<>();
     private boolean classPickingActive = false;
-    private Map<BattleClass, Material> menuItems = new HashMap<>();
+    private Map<BattleClass, Loadout> loadouts = new HashMap<>();
     private Map<Material, BattleClass> materialToBattleClass = new HashMap<>();
-    private Map<BattleClass, List<Component>> menuLores = new HashMap<>();
-    private Map<BattleClass, ItemStack[]> loadouts = new HashMap<>();
     
     /**
      * Registers event listeners, and starts the class picking phase for the given list of teammates
      * 
      * @param plugin The plugin
      * @param newTeamMates The list of teammates. They are assumed to be on the same team. Weird things will happen if they are not.
-     * @param menuItems the Material types to be used in the menu to represent each BattleClass
-     * @param menuLores the lore to be added to the menu items to be used as a description for each BattleClass
-     * @param loadouts the inventory contents for each BattleClass
+     * @param loadouts the loadouts for each BattleClass
      */
     public void start(Main plugin, List<Player> newTeamMates, 
-                      Map<BattleClass, Material> menuItems, 
-                      Map<BattleClass, List<Component>> menuLores, 
-                      Map<BattleClass, ItemStack[]> loadouts) {
+                      Map<BattleClass, Loadout> loadouts) {
         plugin.getServer().getPluginManager().registerEvents(this, plugin);
-        this.menuItems = menuItems;
         this.materialToBattleClass = new HashMap<>();
-        for (Map.Entry<BattleClass, Material> entry : menuItems.entrySet()) {
-            this.materialToBattleClass.put(entry.getValue(), entry.getKey());
+        for (Map.Entry<BattleClass, Loadout> entry : loadouts.entrySet()) {
+            this.materialToBattleClass.put(entry.getValue().getMenuItem().getType(), entry.getKey());
         }
-        this.menuLores = menuLores;
         this.loadouts = loadouts;
         teamMates.clear();
         teamMates.addAll(newTeamMates);
@@ -260,7 +252,7 @@ public class ClassPicker implements Listener {
     private void assignClass(Player teamMate, BattleClass battleClass) {
         pickedBattleClasses.put(teamMate.getUniqueId(), battleClass);
         teamMate.getInventory().clear();
-        ItemStack[] loadout = loadouts.get(battleClass);
+        ItemStack[] loadout = loadouts.get(battleClass).getContents();
         teamMate.getInventory().setContents(loadout);
         teamMate.sendMessage(Component.text("Selected ")
                 .append(Component.text(battleClass.getName())));
@@ -297,11 +289,7 @@ public class ClassPicker implements Listener {
         Inventory newGui = Bukkit.createInventory(null, 9, TITLE);
         int column = 1;
         for (BattleClass battleClass : BattleClass.values()) {
-            ItemStack menuItem = new ItemStack(menuItems.get(battleClass));
-            ItemMeta menuItemMeta = menuItem.getItemMeta();
-            menuItemMeta.displayName(Component.text(battleClass.getName()));
-            menuItemMeta.lore(menuLores.get(battleClass));
-            menuItem.setItemMeta(menuItemMeta);
+            ItemStack menuItem = loadouts.get(battleClass).getMenuItem();
             newGui.setItem(getSlotIndex(1, column), menuItem);
             column++;
         }

--- a/src/main/java/org/braekpo1nt/mctmanager/games/game/capturetheflag/Loadout.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/game/capturetheflag/Loadout.java
@@ -1,0 +1,49 @@
+package org.braekpo1nt.mctmanager.games.game.capturetheflag;
+
+import net.kyori.adventure.text.Component;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.List;
+
+public class Loadout {
+    /**
+     * The menu item to represent this loadout
+     */
+    private final ItemStack menuItem;
+    /**
+     * the inventory contents for this loadout
+     */
+    private final ItemStack[] inventory;
+    
+    /**
+     * 
+     * @param menuName The name to display for this menu item
+     * @param menuMaterial The Material types to be used in the menu to represent this loadout
+     * @param menuDescription The lore to be added to the menu item's meta to be used as a description for each loadout
+     * @param contents The inventory contents of this loadout
+     */
+    public Loadout(String menuName, Material menuMaterial, List<Component> menuDescription, ItemStack[] contents) {
+        this.inventory = contents;
+        this.menuItem = new ItemStack(menuMaterial);
+        ItemMeta menuItemMeta = this.menuItem.getItemMeta();
+        menuItemMeta.displayName(Component.text(menuName));
+        menuItemMeta.lore(menuDescription);
+        this.menuItem.setItemMeta(menuItemMeta);
+    }
+    
+    /**
+     * @return The menu item to represent this loadout
+     */
+    public ItemStack getMenuItem() {
+        return menuItem;
+    }
+    
+    /**
+     * @return the inventory contents for this loadout
+     */
+    public ItemStack[] getContents() {
+        return inventory;
+    }
+}

--- a/src/main/java/org/braekpo1nt/mctmanager/games/game/capturetheflag/config/CaptureTheFlagConfig.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/game/capturetheflag/config/CaptureTheFlagConfig.java
@@ -7,13 +7,12 @@ import org.braekpo1nt.mctmanager.games.game.capturetheflag.BattleClass;
 import org.braekpo1nt.mctmanager.games.game.config.BoundingBoxDTO;
 import org.braekpo1nt.mctmanager.games.game.config.inventory.InventoryContentsDTO;
 import org.bukkit.Material;
-import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
 
 import java.util.List;
 import java.util.Map;
 
-record CaptureTheFlagConfig(String version, String world, Vector spawnObservatory, List<ArenaDTO> arenas, Map<BattleClass, Loadout> loadouts, BoundingBoxDTO spectatorArea, Scores scores, Durations durations, JsonElement description) {
+record CaptureTheFlagConfig(String version, String world, Vector spawnObservatory, List<ArenaDTO> arenas, Map<BattleClass, LoadoutDTO> loadouts, BoundingBoxDTO spectatorArea, Scores scores, Durations durations, JsonElement description) {
     
     record ArenaDTO(Vector northSpawn, Vector southSpawn, Vector northFlag, Vector southFlag, Vector northBarrier, Vector southBarrier, Arena.BarrierSize barrierSize, BoundingBoxDTO boundingBox) {
     }
@@ -24,7 +23,7 @@ record CaptureTheFlagConfig(String version, String world, Vector spawnObservator
      * @param menuLore the description to show on the menu item when you hover over it (it's just an item lore)
      * @param inventory the player's inventory when they select this class
      */
-    record Loadout(Material menuItem, List<JsonElement> menuLore, InventoryContentsDTO inventory) {
+    record LoadoutDTO(Material menuItem, List<JsonElement> menuLore, InventoryContentsDTO inventory) {
     }
     
     /**

--- a/src/main/java/org/braekpo1nt/mctmanager/games/game/capturetheflag/config/CaptureTheFlagConfig.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/game/capturetheflag/config/CaptureTheFlagConfig.java
@@ -5,8 +5,6 @@ import com.google.gson.JsonElement;
 import org.braekpo1nt.mctmanager.games.game.capturetheflag.Arena;
 import org.braekpo1nt.mctmanager.games.game.capturetheflag.BattleClass;
 import org.braekpo1nt.mctmanager.games.game.config.BoundingBoxDTO;
-import org.braekpo1nt.mctmanager.games.game.config.inventory.InventoryContentsDTO;
-import org.bukkit.Material;
 import org.bukkit.util.Vector;
 
 import java.util.List;
@@ -15,15 +13,6 @@ import java.util.Map;
 record CaptureTheFlagConfig(String version, String world, Vector spawnObservatory, List<ArenaDTO> arenas, Map<BattleClass, LoadoutDTO> loadouts, BoundingBoxDTO spectatorArea, Scores scores, Durations durations, JsonElement description) {
     
     record ArenaDTO(Vector northSpawn, Vector southSpawn, Vector northFlag, Vector southFlag, Vector northBarrier, Vector southBarrier, Arena.BarrierSize barrierSize, BoundingBoxDTO boundingBox) {
-    }
-    
-    /**
-     * Represents a loadout for a BattleClass
-     * @param menuItem the item Material Type to use in the ClassPicker menu to represent the BattleClass
-     * @param menuLore the description to show on the menu item when you hover over it (it's just an item lore)
-     * @param inventory the player's inventory when they select this class
-     */
-    record LoadoutDTO(Material menuItem, List<JsonElement> menuLore, InventoryContentsDTO inventory) {
     }
     
     /**

--- a/src/main/java/org/braekpo1nt/mctmanager/games/game/capturetheflag/config/CaptureTheFlagConfig.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/game/capturetheflag/config/CaptureTheFlagConfig.java
@@ -6,14 +6,25 @@ import org.braekpo1nt.mctmanager.games.game.capturetheflag.Arena;
 import org.braekpo1nt.mctmanager.games.game.capturetheflag.BattleClass;
 import org.braekpo1nt.mctmanager.games.game.config.BoundingBoxDTO;
 import org.braekpo1nt.mctmanager.games.game.config.inventory.InventoryContentsDTO;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
 
 import java.util.List;
 import java.util.Map;
 
-record CaptureTheFlagConfig(String version, String world, Vector spawnObservatory, List<ArenaDTO> arenas, Map<BattleClass, InventoryContentsDTO> loadouts, BoundingBoxDTO spectatorArea, Scores scores, Durations durations, JsonElement description) {
+record CaptureTheFlagConfig(String version, String world, Vector spawnObservatory, List<ArenaDTO> arenas, Map<BattleClass, Loadout> loadouts, BoundingBoxDTO spectatorArea, Scores scores, Durations durations, JsonElement description) {
     
     record ArenaDTO(Vector northSpawn, Vector southSpawn, Vector northFlag, Vector southFlag, Vector northBarrier, Vector southBarrier, Arena.BarrierSize barrierSize, BoundingBoxDTO boundingBox) {
+    }
+    
+    /**
+     * Represents a loadout for a BattleClass
+     * @param menuItem the item Material Type to use in the ClassPicker menu to represent the BattleClass
+     * @param menuLore the description to show on the menu item when you hover over it (it's just an item lore)
+     * @param inventory the player's inventory when they select this class
+     */
+    record Loadout(Material menuItem, List<JsonElement> menuLore, InventoryContentsDTO inventory) {
     }
     
     /**

--- a/src/main/java/org/braekpo1nt/mctmanager/games/game/capturetheflag/config/CaptureTheFlagStorageUtil.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/game/capturetheflag/config/CaptureTheFlagStorageUtil.java
@@ -12,6 +12,7 @@ import org.braekpo1nt.mctmanager.games.game.capturetheflag.BattleClass;
 import org.braekpo1nt.mctmanager.games.game.capturetheflag.Loadout;
 import org.braekpo1nt.mctmanager.games.game.config.GameConfigStorageUtil;
 import org.braekpo1nt.mctmanager.games.game.config.inventory.InventoryContentsDTO;
+import org.braekpo1nt.mctmanager.games.game.config.inventory.ItemStackDTO;
 import org.braekpo1nt.mctmanager.games.game.config.inventory.meta.ItemMetaDTO;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -106,8 +107,18 @@ public class CaptureTheFlagStorageUtil extends GameConfigStorageUtil<CaptureTheF
         Preconditions.checkArgument(inventory != null, "loadout.inventory can't be null");
         Preconditions.checkArgument(inventory.contents() != null, "loadout.inventory.contents can't be null");
         Preconditions.checkArgument(inventory.contents().size() <= 41, "loadout.inventory.contents can't contain more than 41 entries");
-        Preconditions.checkArgument(inventory.contents().keySet().stream().max(Integer::compareTo).orElse(0) <= 40, "loadout.inventory.contents indexes can't be greater than 40");
-        Preconditions.checkArgument(0 <= inventory.contents().keySet().stream().min(Integer::compareTo).orElse(0), "loadout.inventory.contents indexes can't be less than 0");
+        for (Map.Entry<Integer, ItemStackDTO> entry : inventory.contents().entrySet()) {
+            int slot = entry.getKey();
+            Preconditions.checkArgument(0 <= slot && slot <= 40, "loadout.inventory.contents index (%s) must be between 0 and 40 (inclusive)", slot);
+            ItemStackDTO item = entry.getValue();
+            itemIsValid(item, slot);
+        }
+    }
+    
+    private void itemIsValid(@Nullable ItemStackDTO item, int slot) {
+        if (item != null) {
+            Preconditions.checkArgument(item.getType() != null, "loadout.inventory.contents item.type can't be null (slot index %s)", slot);
+        }
     }
     
     @Override

--- a/src/main/java/org/braekpo1nt/mctmanager/games/game/capturetheflag/config/CaptureTheFlagStorageUtil.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/game/capturetheflag/config/CaptureTheFlagStorageUtil.java
@@ -1,6 +1,7 @@
 package org.braekpo1nt.mctmanager.games.game.capturetheflag.config;
 
 import com.google.common.base.Preconditions;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonIOException;
 import com.google.gson.JsonSyntaxException;
 import net.kyori.adventure.text.Component;
@@ -8,10 +9,13 @@ import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import org.braekpo1nt.mctmanager.Main;
 import org.braekpo1nt.mctmanager.games.game.capturetheflag.Arena;
 import org.braekpo1nt.mctmanager.games.game.capturetheflag.BattleClass;
+import org.braekpo1nt.mctmanager.games.game.config.ConfigUtil;
 import org.braekpo1nt.mctmanager.games.game.config.GameConfigStorageUtil;
 import org.braekpo1nt.mctmanager.games.game.config.inventory.InventoryContentsDTO;
+import org.braekpo1nt.mctmanager.games.game.config.inventory.meta.ItemMetaDTO;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.BoundingBox;
@@ -19,10 +23,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class CaptureTheFlagStorageUtil extends GameConfigStorageUtil<CaptureTheFlagConfig> {
     private CaptureTheFlagConfig captureTheFlagConfig = null;
@@ -31,6 +32,8 @@ public class CaptureTheFlagStorageUtil extends GameConfigStorageUtil<CaptureTheF
     private List<Arena> arenas;
     private Component description;
     private Map<BattleClass, ItemStack[]> loadouts;
+    private Map<BattleClass, Material> menuItems;
+    private Map<BattleClass, List<Component>> menuLores;
     
     public CaptureTheFlagStorageUtil(File configDirectory) {
         super(configDirectory, "captureTheFlagConfig.json", CaptureTheFlagConfig.class);
@@ -77,13 +80,12 @@ public class CaptureTheFlagStorageUtil extends GameConfigStorageUtil<CaptureTheF
         Preconditions.checkArgument(config.durations().roundTimer() >= 0, "durations.roundTimer (%s) can't be negative", config.durations().roundTimer());
         Preconditions.checkArgument(config.loadouts() != null, "loadouts can't be null");
         Preconditions.checkArgument(config.loadouts().keySet().containsAll(List.of(BattleClass.values())), "loadouts must contain an entry for each BattleClass");
+        Set<Material> uniqueMenuItems = new HashSet<>();
         for (BattleClass battleClass : BattleClass.values()) {
-            InventoryContentsDTO loadout = config.loadouts().get(battleClass);
-            Preconditions.checkArgument(loadout != null, "loadouts can't be null");
-            Preconditions.checkArgument(loadout.contents() != null, "loadout contents can't be null");
-            Preconditions.checkArgument(loadout.contents().size() <= 41, "loadout contents can't contain more than 41 entries");
-            Preconditions.checkArgument(loadout.contents().keySet().stream().max(Integer::compareTo).orElse(0) <= 40, "loadout contents indexes can't be greater than 40");
-            Preconditions.checkArgument(0 <= loadout.contents().keySet().stream().min(Integer::compareTo).orElse(0), "loadout contents indexes can't be less than 0");
+            CaptureTheFlagConfig.Loadout loadout = config.loadouts().get(battleClass);
+            Preconditions.checkArgument(!uniqueMenuItems.contains(loadout.menuItem()), "loadout.menuItem %s for BattleClass %s is not unique", loadout.menuItem(), battleClass);
+            uniqueMenuItems.add(loadout.menuItem());
+            loadoutIsValid(loadout);
         }
         try {
             GsonComponentSerializer.gson().deserializeFromTree(config.description());
@@ -93,6 +95,24 @@ public class CaptureTheFlagStorageUtil extends GameConfigStorageUtil<CaptureTheF
         return true;
     }
     
+    private void loadoutIsValid(CaptureTheFlagConfig.Loadout loadout) {
+        Preconditions.checkArgument(loadout.menuItem() != null, "loadout.menuItem can't be null");
+        Preconditions.checkArgument(loadout.menuLore() != null, "loadout.menuLore can't be null");
+        for (JsonElement line : loadout.menuLore()) {
+            Preconditions.checkArgument(line != null, "loadout.menuLore can't have any null entries");
+        }
+        ItemMetaDTO.toLore(loadout.menuLore());
+        inventoryIsValid(loadout.inventory());
+    }
+    
+    private void inventoryIsValid(InventoryContentsDTO inventory) {
+        Preconditions.checkArgument(inventory != null, "loadout.inventory can't be null");
+        Preconditions.checkArgument(inventory.contents() != null, "loadout.inventory.contents can't be null");
+        Preconditions.checkArgument(inventory.contents().size() <= 41, "loadout.inventory.contents can't contain more than 41 entries");
+        Preconditions.checkArgument(inventory.contents().keySet().stream().max(Integer::compareTo).orElse(0) <= 40, "loadout.inventory.contents indexes can't be greater than 40");
+        Preconditions.checkArgument(0 <= inventory.contents().keySet().stream().min(Integer::compareTo).orElse(0), "loadout.inventory.contents indexes can't be less than 0");
+    }
+    
     @Override
     protected void setConfig(CaptureTheFlagConfig config) {
         World newWorld = Bukkit.getWorld(config.world());
@@ -100,8 +120,15 @@ public class CaptureTheFlagStorageUtil extends GameConfigStorageUtil<CaptureTheF
         Location newSpawnObservatory = config.spawnObservatory().toLocation(newWorld);
         Component newDescription = GsonComponentSerializer.gson().deserializeFromTree(config.description());
         Map<BattleClass, ItemStack[]> newLoadouts = new HashMap<>();
-        for (Map.Entry<BattleClass, InventoryContentsDTO> loadout : config.loadouts().entrySet()) {
-            newLoadouts.put(loadout.getKey(), loadout.getValue().toInventoryContents());
+        Map<BattleClass, Material> newMenuItems = new HashMap<>();
+        Map<BattleClass, List<Component>> newMenuLores = new HashMap<>();
+        for (Map.Entry<BattleClass, CaptureTheFlagConfig.Loadout> entry : config.loadouts().entrySet()) {
+            BattleClass battleClass = entry.getKey();
+            CaptureTheFlagConfig.Loadout loadout = entry.getValue();
+            newLoadouts.put(battleClass, loadout.inventory().toInventoryContents());
+            newMenuItems.put(battleClass, loadout.menuItem());
+            List<Component> menuLore = ItemMetaDTO.toLore(loadout.menuLore());
+            newMenuLores.put(battleClass, menuLore);
         }
         // now it's confirmed everything works, so set the actual fields
         this.world = newWorld;
@@ -110,6 +137,8 @@ public class CaptureTheFlagStorageUtil extends GameConfigStorageUtil<CaptureTheF
         this.description = newDescription;
         this.captureTheFlagConfig = config;
         this.loadouts = newLoadouts;
+        this.menuItems = newMenuItems;
+        this.menuLores = newMenuLores;
     }
     
     private List<Arena> toArenas(List<CaptureTheFlagConfig.ArenaDTO> arenaDTOS, World arenaWorld) {
@@ -180,5 +209,13 @@ public class CaptureTheFlagStorageUtil extends GameConfigStorageUtil<CaptureTheF
     
     public Map<BattleClass, ItemStack[]> getLoadouts() {
         return loadouts;
+    }
+    
+    public Map<BattleClass, Material> getMenuItems() {
+        return menuItems;
+    }
+    
+    public Map<BattleClass, List<Component>> getMenuLores() {
+        return menuLores;
     }
 }

--- a/src/main/java/org/braekpo1nt/mctmanager/games/game/capturetheflag/config/CaptureTheFlagStorageUtil.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/game/capturetheflag/config/CaptureTheFlagStorageUtil.java
@@ -17,7 +17,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
-import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.BoundingBox;
 import org.jetbrains.annotations.Nullable;
 
@@ -80,7 +79,7 @@ public class CaptureTheFlagStorageUtil extends GameConfigStorageUtil<CaptureTheF
         Preconditions.checkArgument(config.loadouts().keySet().containsAll(List.of(BattleClass.values())), "loadouts must contain an entry for each BattleClass");
         Set<Material> uniqueMenuItems = new HashSet<>();
         for (BattleClass battleClass : BattleClass.values()) {
-            CaptureTheFlagConfig.LoadoutDTO loadout = config.loadouts().get(battleClass);
+            LoadoutDTO loadout = config.loadouts().get(battleClass);
             Preconditions.checkArgument(!uniqueMenuItems.contains(loadout.menuItem()), "loadout.menuItem %s for BattleClass %s is not unique", loadout.menuItem(), battleClass);
             uniqueMenuItems.add(loadout.menuItem());
             loadoutIsValid(loadout);
@@ -93,7 +92,7 @@ public class CaptureTheFlagStorageUtil extends GameConfigStorageUtil<CaptureTheF
         return true;
     }
     
-    private void loadoutIsValid(CaptureTheFlagConfig.LoadoutDTO loadout) {
+    private void loadoutIsValid(LoadoutDTO loadout) {
         Preconditions.checkArgument(loadout.menuItem() != null, "loadout.menuItem can't be null");
         Preconditions.checkArgument(loadout.menuLore() != null, "loadout.menuLore can't be null");
         for (JsonElement line : loadout.menuLore()) {
@@ -118,9 +117,9 @@ public class CaptureTheFlagStorageUtil extends GameConfigStorageUtil<CaptureTheF
         Location newSpawnObservatory = config.spawnObservatory().toLocation(newWorld);
         Component newDescription = GsonComponentSerializer.gson().deserializeFromTree(config.description());
         Map<BattleClass, Loadout> newLoadouts = new HashMap<>();
-        for (Map.Entry<BattleClass, CaptureTheFlagConfig.LoadoutDTO> entry : config.loadouts().entrySet()) {
+        for (Map.Entry<BattleClass, LoadoutDTO> entry : config.loadouts().entrySet()) {
             BattleClass battleClass = entry.getKey();
-            CaptureTheFlagConfig.LoadoutDTO loadout = entry.getValue();
+            LoadoutDTO loadout = entry.getValue();
             List<Component> menuDescription = ItemMetaDTO.toLore(loadout.menuLore());
             Loadout newLoadout = new Loadout(battleClass.getName(), loadout.menuItem(), menuDescription, loadout.inventory().toInventoryContents());
             newLoadouts.put(battleClass, newLoadout);

--- a/src/main/java/org/braekpo1nt/mctmanager/games/game/capturetheflag/config/LoadoutDTO.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/game/capturetheflag/config/LoadoutDTO.java
@@ -1,0 +1,17 @@
+package org.braekpo1nt.mctmanager.games.game.capturetheflag.config;
+
+import com.google.gson.JsonElement;
+import org.braekpo1nt.mctmanager.games.game.config.inventory.InventoryContentsDTO;
+import org.bukkit.Material;
+
+import java.util.List;
+
+/**
+ * Represents a loadout for a BattleClass
+ *
+ * @param menuItem  the item Material Type to use in the ClassPicker menu to represent the BattleClass
+ * @param menuLore  the description to show on the menu item when you hover over it (it's just an item lore)
+ * @param inventory the player's inventory when they select this class
+ */
+record LoadoutDTO(Material menuItem, List<JsonElement> menuLore, InventoryContentsDTO inventory) {
+}

--- a/src/main/java/org/braekpo1nt/mctmanager/games/game/clockwork/ClockworkGame.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/game/clockwork/ClockworkGame.java
@@ -7,6 +7,7 @@ import org.braekpo1nt.mctmanager.games.game.clockwork.config.ClockworkStorageUti
 import org.braekpo1nt.mctmanager.games.game.enums.GameType;
 import org.braekpo1nt.mctmanager.games.game.interfaces.Configurable;
 import org.braekpo1nt.mctmanager.games.game.interfaces.MCTGame;
+import org.braekpo1nt.mctmanager.games.utils.ParticipantInitializer;
 import org.braekpo1nt.mctmanager.ui.sidebar.Headerable;
 import org.braekpo1nt.mctmanager.ui.sidebar.KeyLine;
 import org.braekpo1nt.mctmanager.ui.sidebar.Sidebar;
@@ -84,6 +85,8 @@ public class ClockworkGame implements Listener, MCTGame, Configurable, Headerabl
     private void initializeParticipant(Player participant) {
         participants.add(participant);
         sidebar.addPlayer(participant);
+        ParticipantInitializer.clearStatusEffects(participant);
+        ParticipantInitializer.resetHealthAndHunger(participant);
     }
     
     private void startAdmins(List<Player> newAdmins) {

--- a/src/main/java/org/braekpo1nt/mctmanager/games/game/config/ConfigUtil.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/game/config/ConfigUtil.java
@@ -1,0 +1,44 @@
+package org.braekpo1nt.mctmanager.games.game.config;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonIOException;
+import com.google.gson.JsonSyntaxException;
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
+import net.kyori.adventure.text.Component;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.Objects;
+
+public class ConfigUtil {
+    
+    /**
+     * 
+     * @param componentDTO a {@link JsonElement} representing a {@link Component}.
+     *                     (essentially a /tellraw argument)
+     * @return the componentDTO as a {@link Component} object 
+     * @throws IllegalArgumentException if the provided componentDTO can't be parsed into a {@link Component} object.
+     */
+    public static @NotNull Component toComponent(final @NotNull JsonElement componentDTO) throws JsonIOException, JsonSyntaxException {
+        try {
+            return GsonComponentSerializer.gson().deserializeFromTree(componentDTO);
+        } catch (JsonIOException | JsonSyntaxException e) {
+            throw new IllegalArgumentException(String.format("Unable to parse JsonElement as Component: \"%s\"", componentDTO), e);
+        }
+    }
+    
+    /**
+     * 
+     * @param componentDTOs a list of {@link JsonElement}s representing {@link Component}s.
+     *                      (essentially a list of /tellraw arguments)
+     * @return a List containing all the componentDTOs as {@link Component} objects
+     * @throws IllegalArgumentException if any one of the provided componentDTOs can't be parsed into a {@link Component} object.
+     */
+    public static @NotNull List<Component> toComponents(final @NotNull List<JsonElement> componentDTOs) throws JsonIOException, JsonSyntaxException {
+        return componentDTOs.stream().filter(Objects::nonNull).map(ConfigUtil::toComponent).toList();
+    }
+    
+    private ConfigUtil() {
+        // do not instantiate
+    }
+}

--- a/src/main/java/org/braekpo1nt/mctmanager/games/game/config/inventory/ItemStackDTO.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/game/config/inventory/ItemStackDTO.java
@@ -1,5 +1,6 @@
 package org.braekpo1nt.mctmanager.games.game.config.inventory;
 
+import com.google.common.base.Preconditions;
 import org.braekpo1nt.mctmanager.games.game.config.inventory.meta.ItemMetaDTO;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
@@ -25,11 +26,16 @@ public class ItemStackDTO {
      * @return the ItemStack object which was represented by this DTO 
      */
     public ItemStack toItemStack() {
+        Preconditions.checkArgument(type != null, "type (Material) cannot be null");
         ItemStack stack = new ItemStack(type, amount);
         if (itemMeta != null) {
             ItemMeta meta = stack.getItemMeta();
             stack.setItemMeta(itemMeta.toItemMeta(meta));
         }
         return stack;
+    }
+    
+    public Material getType() {
+        return type;
     }
 }

--- a/src/main/java/org/braekpo1nt/mctmanager/games/game/config/inventory/ItemStackDTO.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/game/config/inventory/ItemStackDTO.java
@@ -29,8 +29,7 @@ public class ItemStackDTO {
         Preconditions.checkArgument(type != null, "type (Material) cannot be null");
         ItemStack stack = new ItemStack(type, amount);
         if (itemMeta != null) {
-            ItemMeta meta = stack.getItemMeta();
-            stack.setItemMeta(itemMeta.toItemMeta(meta));
+            stack.editMeta(meta -> itemMeta.toItemMeta(meta));
         }
         return stack;
     }

--- a/src/main/java/org/braekpo1nt/mctmanager/games/game/config/inventory/meta/ItemMetaDTO.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/game/config/inventory/meta/ItemMetaDTO.java
@@ -2,13 +2,17 @@ package org.braekpo1nt.mctmanager.games.game.config.inventory.meta;
 
 import com.destroystokyo.paper.Namespaced;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonIOException;
+import com.google.gson.JsonSyntaxException;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
+import org.braekpo1nt.mctmanager.games.game.config.ConfigUtil;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.enchantments.EnchantmentWrapper;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
@@ -32,6 +36,21 @@ public class ItemMetaDTO {
     protected @Nullable Set<Namespaced> placeableKeys;
     
     /**
+     * 
+     * @param loreDTO the list of {@link JsonElement}s that represent the 
+     *                list of {@link Component}s for an {@link ItemMeta}'s lore
+     * @return the loreDTO as a list of {@link Component}s for use as an {@link ItemMeta}'s lore
+     * @throws IllegalArgumentException if any of the given loreDTO elements can't be parsed as a {@link Component}
+     */
+    public static @NotNull List<Component> toLore(@NotNull List<@NotNull JsonElement> loreDTO) {
+        try {
+            return ConfigUtil.toComponents(loreDTO);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("lore is invalid", e);
+        }
+    }
+    
+    /**
      * Imbues the provided ItemMeta with the attributes of this ItemMetaDTO
      * @param meta the ItemMeta to be modified
      * @return the provided ItemMeta, after all the attributes have been set 
@@ -39,12 +58,11 @@ public class ItemMetaDTO {
      */
     public ItemMeta toItemMeta(ItemMeta meta) {
         if (displayName != null) {
-            Component newDisplayName = GsonComponentSerializer.gson().deserializeFromTree(displayName);
+            Component newDisplayName = ConfigUtil.toComponent(displayName);
             meta.displayName(newDisplayName);
         }
         if (lore != null) {
-            List<Component> newLore = lore.stream().map(line -> GsonComponentSerializer.gson().deserializeFromTree(line)).toList();
-            meta.lore(newLore);
+            meta.lore(ItemMetaDTO.toLore(lore));
         }
         if (enchants != null) {
             for (Map.Entry<String, Integer> enchant : enchants.entrySet()) {

--- a/src/main/java/org/braekpo1nt/mctmanager/games/game/mecha/MechaGame.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/game/mecha/MechaGame.java
@@ -233,7 +233,7 @@ public class MechaGame implements MCTGame, Configurable, Listener, Headerable {
             }
         }
     }
-
+    
     @Override
     public void onParticipantJoin(Player participant) {
         if (participantShouldRejoin(participant)) {
@@ -246,6 +246,13 @@ public class MechaGame implements MCTGame, Configurable, Listener, Headerable {
                     .append(Component.text(" is joining MECHA!"))
                     .color(NamedTextColor.YELLOW));
             initializeParticipant(participant);
+            if (!mechaHasStarted) {
+                List<String> teams = gameManager.getTeamNames(participants);
+                createPlatforms(teams);
+                teleportTeams(teams);
+            } else {
+                participant.teleport(storageUtil.getPlatformSpawns().get(0));
+            }
         }
         sidebar.updateLines(participant.getUniqueId(),
                 new KeyLine("title", title),

--- a/src/main/java/org/braekpo1nt/mctmanager/games/game/mecha/MechaGame.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/game/mecha/MechaGame.java
@@ -237,9 +237,6 @@ public class MechaGame implements MCTGame, Configurable, Listener, Headerable {
     @Override
     public void onParticipantJoin(Player participant) {
         if (participantShouldRejoin(participant)) {
-            messageAllParticipants(Component.text(participant.getName())
-                    .append(Component.text(" is rejoining MECHA!"))
-                    .color(NamedTextColor.YELLOW));
             rejoinParticipant(participant);
         } else {
             messageAllParticipants(Component.text(participant.getName())

--- a/src/main/java/org/braekpo1nt/mctmanager/games/game/parkourpathway/ParkourPathwayGame.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/game/parkourpathway/ParkourPathwayGame.java
@@ -161,6 +161,8 @@ public class ParkourPathwayGame implements MCTGame, Configurable, Listener, Head
     
     private void resetParticipant(Player participant) {
         participant.getInventory().clear();
+        ParticipantInitializer.clearStatusEffects(participant);
+        ParticipantInitializer.resetHealthAndHunger(participant);
         sidebar.removePlayer(participant.getUniqueId());
     }
     

--- a/src/main/java/org/braekpo1nt/mctmanager/games/game/parkourpathway/ParkourPathwayGame.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/game/parkourpathway/ParkourPathwayGame.java
@@ -188,6 +188,8 @@ public class ParkourPathwayGame implements MCTGame, Configurable, Listener, Head
         participant.setGameMode(GameMode.ADVENTURE);
         ParticipantInitializer.clearStatusEffects(participant);
         ParticipantInitializer.resetHealthAndHunger(participant);
+        Location respawn = storageUtil.getCheckPoints().get(currentCheckpoints.get(participant.getUniqueId())).respawn();
+        participant.teleport(respawn);
         sidebar.updateLine(participant.getUniqueId(), "title", title);
         updateCheckpointSidebar(participant);
     }

--- a/src/main/java/org/braekpo1nt/mctmanager/games/voting/VoteManager.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/voting/VoteManager.java
@@ -15,6 +15,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
@@ -300,6 +301,23 @@ public class VoteManager implements Listener {
             participant.sendMessage(Component.text("You didn't vote for a game. Use the nether star to vote.")
                     .color(NamedTextColor.YELLOW));
         }
+    }
+    
+    @EventHandler
+    public void onPlayerDamage(EntityDamageEvent event) {
+        if (!voting) {
+            return;
+        }
+        if (event.getCause().equals(EntityDamageEvent.DamageCause.VOID)) {
+            return;
+        }
+        if (!(event.getEntity() instanceof Player voter)) {
+            return;
+        }
+        if (!voters.contains(voter)) {
+            return;
+        }
+        event.setCancelled(true);
     }
     
     /**

--- a/src/main/java/org/braekpo1nt/mctmanager/hub/HubManager.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/hub/HubManager.java
@@ -53,7 +53,7 @@ public class HubManager implements Listener, Configurable {
     }
     
     /**
-     * Returns the participants to the hub instantly, without a delay
+     * Returns the participants to the hub (either instantly, or with a delay)
      * @param newParticipants the participants to send to the hub
      * @param delay false will perform the teleport instantaneously, true will teleport with a delay
      */

--- a/src/main/resources/org/braekpo1nt/mctmanager/games/game/capturetheflag/config/exampleCaptureTheFlagConfig.json
+++ b/src/main/resources/org/braekpo1nt/mctmanager/games/game/capturetheflag/config/exampleCaptureTheFlagConfig.json
@@ -217,11 +217,11 @@
     "ARCHER": {
       "menuItem": "BOW",
       "menuLore": [
-        {"text":"- Bow"},
-        {"text":"- 16 Arrows"},
-        {"text":"- Wooden Sword"},
-        {"text":"- Chest Plate"},
-        {"text":"- Boots"}
+        "- Bow",
+        "- 16 Arrows",
+        "- Wooden Sword",
+        "- Chest Plate",
+        "- Boots"
       ],
       "inventory": {
         "contents": {
@@ -257,7 +257,10 @@
       "inventory": {
         "contents": {
           "0": {
-            "type": "IRON_SWORD"
+            "type": "IRON_SWORD",
+            "itemMeta": {
+              "displayName": "Assassin's Knife"
+            }
           },
           "1": {
             "type": "COOKED_BEEF",
@@ -271,7 +274,7 @@
       "menuLore": [
         {"text":"- Full Leather Armor"},
         {"text":"- Chainmail Leggings"},
-        {"text":"- No Sword"}
+        {"text":"- No Sword","italic":true}
       ],
       "inventory": {
         "contents": {

--- a/src/main/resources/org/braekpo1nt/mctmanager/games/game/capturetheflag/config/exampleCaptureTheFlagConfig.json
+++ b/src/main/resources/org/braekpo1nt/mctmanager/games/game/capturetheflag/config/exampleCaptureTheFlagConfig.json
@@ -190,71 +190,104 @@
   ],
   "loadouts": {
     "KNIGHT": {
-      "contents": {
-        "36": {
-          "type": "LEATHER_BOOTS"
-        },
-        "38": {
-          "type": "LEATHER_CHESTPLATE"
-        },
-        "0": {
-          "type": "STONE_SWORD"
-        },
-        "1": {
-          "type": "COOKED_BEEF",
-          "amount": 8
+      "menuItem": "STONE_SWORD",
+      "menuLore": [
+        {"text":"- Stone Sword"},
+        {"text":"- Chest Plate"},
+        {"text":"- Boots"}
+      ],
+      "inventory": {
+        "contents": {
+          "36": {
+            "type": "LEATHER_BOOTS"
+          },
+          "38": {
+            "type": "LEATHER_CHESTPLATE"
+          },
+          "0": {
+            "type": "STONE_SWORD"
+          },
+          "1": {
+            "type": "COOKED_BEEF",
+            "amount": 8
+          }
         }
       }
     },
     "ARCHER": {
-      "contents": {
-        "36": {
-          "type": "LEATHER_BOOTS"
-        },
-        "38": {
-          "type": "LEATHER_CHESTPLATE"
-        },
-        "0": {
-          "type": "BOW"
-        },
-        "1": {
-          "type": "WOODEN_SWORD"
-        },
-        "2": {
-          "type": "ARROW",
-          "amount": 16
-        },
-        "3": {
-          "type": "COOKED_BEEF",
-          "amount": 8
+      "menuItem": "BOW",
+      "menuLore": [
+        {"text":"- Bow"},
+        {"text":"- 16 Arrows"},
+        {"text":"- Wooden Sword"},
+        {"text":"- Chest Plate"},
+        {"text":"- Boots"}
+      ],
+      "inventory": {
+        "contents": {
+          "36": {
+            "type": "LEATHER_BOOTS"
+          },
+          "38": {
+            "type": "LEATHER_CHESTPLATE"
+          },
+          "0": {
+            "type": "BOW"
+          },
+          "1": {
+            "type": "WOODEN_SWORD"
+          },
+          "2": {
+            "type": "ARROW",
+            "amount": 16
+          },
+          "3": {
+            "type": "COOKED_BEEF",
+            "amount": 8
+          }
         }
       }
     },
     "ASSASSIN": {
-      "contents": {
-        "0": {
-          "type": "IRON_SWORD"
-        },
-        "1": {
-          "type": "COOKED_BEEF",
-          "amount": 8
+      "menuItem": "IRON_SWORD",
+      "menuLore": [
+        {"text":"- Iron Sword"},
+        {"text":"- No Armor"}
+      ],
+      "inventory": {
+        "contents": {
+          "0": {
+            "type": "IRON_SWORD"
+          },
+          "1": {
+            "type": "COOKED_BEEF",
+            "amount": 8
+          }
         }
       }
     },
     "TANK": {
-      "contents": {
-        "36": {
-          "type": "LEATHER_BOOTS"
-        },
-        "37": {
-          "type": "CHAINMAIL_LEGGINGS"
-        },
-        "38": {
-          "type": "LEATHER_CHESTPLATE"
-        },
-        "0": {
-          "type": "COOKED_BEEF",
-          "amount": 8
+      "menuItem": "LEATHER_CHESTPLATE",
+      "menuLore": [
+        {"text":"- Full Leather Armor"},
+        {"text":"- Chainmail Leggings"},
+        {"text":"- No Sword"}
+      ],
+      "inventory": {
+        "contents": {
+          "36": {
+            "type": "LEATHER_BOOTS"
+          },
+          "37": {
+            "type": "CHAINMAIL_LEGGINGS"
+          },
+          "38": {
+            "type": "LEATHER_CHESTPLATE"
+          },
+          "0": {
+            "type": "COOKED_BEEF",
+            "amount": 8
+          }
         }
       }
     }


### PR DESCRIPTION
closes #395 
- allows you to change the number of games mid event
- handles reloads during events
- handles players leaving during one context and joining in another
- allows loadouts to have their item and description configured (Capture the flag)
- players being damaged during voting are no longer hurt
- 