### PR TITLE
fixed null pointer exception when using preset

### DIFF
--- a/src/main/java/org/braekpo1nt/mctmanager/games/GameManager.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/GameManager.java
@@ -753,8 +753,7 @@ public class GameManager implements Listener {
         }
         List<String> offlineIGNs = gameStateStorageUtil.getOfflineIGNsOnTeam(teamName);
         for (String offlineIGN : offlineIGNs) {
-            OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(offlineIGN);
-            leavePlayer(sender, offlinePlayer, offlineIGN);
+            leaveOfflineIGN(sender, offlineIGN);
         }
     }
     

--- a/src/main/java/org/braekpo1nt/mctmanager/games/gamestate/GameState.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/gamestate/GameState.java
@@ -102,7 +102,7 @@ public class GameState {
      * @param playerUniqueId The UUID of the player to get
      * @return The player with the given UUID, null if the player does not exist.
      */
-    public MCTPlayer getPlayer(UUID playerUniqueId) {
+    public @Nullable MCTPlayer getPlayer(@NotNull UUID playerUniqueId) {
         return players.get(playerUniqueId);
     }
     

--- a/src/main/java/org/braekpo1nt/mctmanager/games/gamestate/GameStateStorageUtil.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/gamestate/GameStateStorageUtil.java
@@ -207,11 +207,14 @@ public class GameStateStorageUtil {
     /**
      * Gets the internal team name of the player with the given UUID
      * @param playerUniqueId The UUID of the player to find the team of
-     * @return The internal team name of the player with the given UUID
-     * @throws NullPointerException if the game state doesn't contain the player's UUID
+     * @return The internal team name of the player with the given UUID, null if the game state doesn't contain the player's UUID
      */
-    public String getPlayerTeamName(UUID playerUniqueId) {
-        return gameState.getPlayer(playerUniqueId).getTeamName();
+    public @Nullable String getPlayerTeamName(@NotNull UUID playerUniqueId) {
+        MCTPlayer player = gameState.getPlayer(playerUniqueId);
+        if (player == null) {
+            return null;
+        }
+        return player.getTeamName();
     }
     
     /**


### PR DESCRIPTION
fixed null pointer exception when using preset because the leavePlayersOnTeam attempted to use the wrong method for removing an offline player from a team