### PR TITLE
Implement splash screen tips

### DIFF
--- a/src/main/java/org/braekpo1nt/mctmanager/games/GameManager.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/GameManager.java
@@ -1075,7 +1075,23 @@ public class GameManager implements Listener {
     public boolean hasTeam(String teamId) {
         return gameStateStorageUtil.containsTeam(teamId);
     }
-    
+
+    /**
+     * Returns a mapping of all teamIds to currently online players of those teams
+     *
+     * @return mapping from all teamIds to their currently online players
+     */
+    public Map<String, List<Player>> getTeamPlayerMapping() {
+        Map<String, List<Player>> teamPlayerMap = new HashMap<>();
+        Set<String> teamIds = getTeamIds();
+
+        for (String teamId : teamIds) {
+            List<Player> playersOnTeam = getOnlinePlayersOnTeam(teamId);
+            teamPlayerMap.put(teamId, playersOnTeam);
+        }
+
+        return teamPlayerMap;
+    }
     /**
      * Checs if the player exists in the game state
      * @param playerUniqueId The UUID of the player to check for

--- a/src/main/java/org/braekpo1nt/mctmanager/games/GameManager.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/GameManager.java
@@ -1077,22 +1077,6 @@ public class GameManager implements Listener {
     }
 
     /**
-     * Returns a mapping of all teamIds to currently online players of those teams
-     *
-     * @return mapping from all teamIds to their currently online players
-     */
-    public Map<String, List<Player>> getTeamPlayerMapping() {
-        Map<String, List<Player>> teamPlayerMap = new HashMap<>();
-        Set<String> teamIds = getTeamIds();
-
-        for (String teamId : teamIds) {
-            List<Player> playersOnTeam = getOnlinePlayersOnTeam(teamId);
-            teamPlayerMap.put(teamId, playersOnTeam);
-        }
-
-        return teamPlayerMap;
-    }
-    /**
      * Checs if the player exists in the game state
      * @param playerUniqueId The UUID of the player to check for
      * @return true if the UUID is in the game state, false otherwise

--- a/src/main/java/org/braekpo1nt/mctmanager/games/event/EventManager.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/event/EventManager.java
@@ -697,10 +697,6 @@ public class EventManager implements Listener {
         gameManager.messageAdmins(message);
     }
 
-    public Map<String, List<Player>> getTeamToOnlinePlayersMapping() {
-        return gameManager.getTeamPlayerMapping();
-    }
-    
     public boolean allGamesHaveBeenPlayed() {
         return currentGameNumber >= maxGames + 1;
     }

--- a/src/main/java/org/braekpo1nt/mctmanager/games/event/EventManager.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/event/EventManager.java
@@ -696,6 +696,10 @@ public class EventManager implements Listener {
     public void messageAllAdmins(Component message) {
         gameManager.messageAdmins(message);
     }
+
+    public Map<String, List<Player>> getTeamToOnlinePlayersMapping() {
+        return gameManager.getTeamPlayerMapping();
+    }
     
     public boolean allGamesHaveBeenPlayed() {
         return currentGameNumber >= maxGames + 1;

--- a/src/main/java/org/braekpo1nt/mctmanager/games/event/config/EventConfig.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/event/config/EventConfig.java
@@ -4,6 +4,8 @@ import lombok.Builder;
 import lombok.Data;
 import net.kyori.adventure.text.Component;
 
+import java.util.List;
+
 @Data
 @Builder
 public class EventConfig {
@@ -14,6 +16,8 @@ public class EventConfig {
     private int startingGameDuration;
     private int backToHubDuration;
     private double[] multipliers;
+    private List<Tip> tips;
+    private int tipsDisplayTimeSeconds;
     private boolean shouldDisplayGameNumber;
     private Component title;
     

--- a/src/main/java/org/braekpo1nt/mctmanager/games/event/config/EventConfigDTO.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/event/config/EventConfigDTO.java
@@ -1,11 +1,19 @@
 package org.braekpo1nt.mctmanager.games.event.config;
 
+import com.google.gson.JsonParseException;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import org.braekpo1nt.mctmanager.Main;
 import org.braekpo1nt.mctmanager.config.validation.Validatable;
 import org.braekpo1nt.mctmanager.config.validation.Validator;
 import org.jetbrains.annotations.NotNull;
 
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.annotations.JsonAdapter;
+
+import java.lang.reflect.Type;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -78,12 +86,20 @@ record EventConfigDTO(
     /**
      * Record to hold the information contained in a @Tip object
      *
-     * @param text     the tip text
+     * @param text     the tip text as a component
      * @param priority the tip priority
      */
-    record TipDTO(String text, int priority) {
+    record TipDTO(@JsonAdapter(ComponentDeserializer.class) Component text, int priority) {
     }
 
+    // Helper class to deserialize the "text" field of a Tip in the json config into a Component
+    static class ComponentDeserializer implements JsonDeserializer<Component> {
+        @Override
+        public Component deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+                throws JsonParseException {
+            return GsonComponentSerializer.gson().deserializeFromTree(json);
+        }
+    }
     /**
      * All units are seconds, none can be negative.
      * @param waitingInHub the time spent waiting in the hub between games (seconds)

--- a/src/main/java/org/braekpo1nt/mctmanager/games/event/config/EventConfigDTO.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/event/config/EventConfigDTO.java
@@ -6,6 +6,9 @@ import org.braekpo1nt.mctmanager.config.validation.Validatable;
 import org.braekpo1nt.mctmanager.config.validation.Validator;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 /**
  * @param title the title of the event, used in the sidebar and for announcing the winner
  * @param multipliers must have at least one element. The nth multiplier is used on the nth game in the event. If there are x multipliers, and we're on game z where z is greater than x, the xth multiplier is used. A multiplier will be multiplied by all points awarded during it's paired game.
@@ -16,6 +19,7 @@ record EventConfigDTO(
         Component title, 
         double[] multipliers, 
         boolean shouldDisplayGameNumber,
+        TipsConfig tips,
         Durations durations) implements Validatable {
     
     @Override
@@ -26,6 +30,9 @@ record EventConfigDTO(
         validator.notNull(this.multipliers, "multipliers");
         validator.validate(this.multipliers.length >= 1, "there must be at least 1 multiplier");
         validator.notNull(this.durations, "durations");
+        validator.notNull(this.tips, "tips");
+        validator.notNull(this.tips.displayTimeSeconds, "display time for tips must be specified");
+        validator.validate(!this.tips.tips().isEmpty(), "there must be at least 1 game tip");
         validator.validate(this.durations.waitingInHub() >= 0, "durations.waitingInHub can't be negative");
         validator.validate(this.durations.halftimeBreak() >= 0, "durations.halftimeBreak can't be negative");
         validator.validate(this.durations.voting() >= 0, "durations.voting can't be negative");
@@ -41,11 +48,42 @@ record EventConfigDTO(
                 .startingGameDuration(this.durations.startingGame)
                 .backToHubDuration(this.durations.backToHub)
                 .multipliers(this.multipliers)
+                .tips(convertTips())
+                .tipsDisplayTimeSeconds(this.tips.displayTimeSeconds())
                 .shouldDisplayGameNumber(this.shouldDisplayGameNumber)
                 .title(this.title)
                 .build();
     }
-    
+
+    /**
+     * Converts the Tip records to a List of Tip objects
+     */
+    private List<Tip> convertTips() {
+        return this.tips.tips().stream()
+                .map(tipDto -> new Tip(
+                        tipDto.priority(),
+                        tipDto.text()))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Record to hold all configured tips and the tip display time
+     *
+     * @param displayTimeSeconds the amount of seconds to display a tip
+     * @param tips               the tips, consisting of text and a priority
+     */
+    record TipsConfig(int displayTimeSeconds, List<TipDTO> tips) {
+    }
+
+    /**
+     * Record to hold the information contained in a @Tip object
+     *
+     * @param text     the tip text
+     * @param priority the tip priority
+     */
+    record TipDTO(String text, int priority) {
+    }
+
     /**
      * All units are seconds, none can be negative.
      * @param waitingInHub the time spent waiting in the hub between games (seconds)

--- a/src/main/java/org/braekpo1nt/mctmanager/games/event/config/Tip.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/event/config/Tip.java
@@ -1,0 +1,82 @@
+package org.braekpo1nt.mctmanager.games.event.config;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+public class Tip {
+    private final int priority;
+    private final String tip;
+
+    public Tip(int priority, String tip) {
+        this.priority = priority;
+        this.tip = tip;
+    }
+
+    public String getTip() {
+        return tip;
+    }
+
+    public int getPriority() {
+        return priority;
+    }
+
+    /**
+     * Selects tips with weighted randomness based on priority
+     *
+     * @param tips List of tips to select from
+     * @return A randomly selected tip, with higher priority tips more likely to be
+     *         chosen
+     */
+    public static Tip selectWeightedRandomTip(List<Tip> tips) {
+        if (tips == null || tips.isEmpty()) {
+            throw new IllegalArgumentException("Tips list cannot be null or empty");
+        }
+
+        int totalWeight = tips.stream()
+                .mapToInt(Tip::getPriority)
+                .sum();
+
+        Random random = new Random();
+        int randomPoint = random.nextInt(totalWeight);
+
+        // Select tip based on weighted randomness
+        int cumulativeWeight = 0;
+        for (Tip tip : tips) {
+            cumulativeWeight += tip.getPriority();
+            if (randomPoint < cumulativeWeight) {
+                return tip;
+            }
+        }
+
+        return tips.get(0);
+    }
+
+    /**
+     * Selects multiple tips with weighted randomness, ensuring no repeats
+     * 
+     * @param tips  list of tips to select from
+     * @param count number of tips to select
+     * @return list of unique tips
+     */
+    public static List<Tip> selectMultipleWeightedRandomTips(List<Tip> tips, int count) {
+        List<Tip> selectedTips = new ArrayList<>();
+        List<Tip> remainingTips = new ArrayList<>(tips);
+
+        while (selectedTips.size() < count) {
+            // If remaining tips is empty, refill with original tips
+            if (remainingTips.isEmpty()) {
+                remainingTips = new ArrayList<>(tips);
+            }
+
+            Tip selectedTip = selectWeightedRandomTip(remainingTips);
+
+            if (!selectedTips.contains(selectedTip)) {
+                selectedTips.add(selectedTip);
+            }
+
+            remainingTips.remove(selectedTip);
+        }
+        return selectedTips;
+    }
+}

--- a/src/main/java/org/braekpo1nt/mctmanager/games/event/config/Tip.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/event/config/Tip.java
@@ -1,19 +1,21 @@
 package org.braekpo1nt.mctmanager.games.event.config;
 
+import net.kyori.adventure.text.Component;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
 public class Tip {
     private final int priority;
-    private final String tip;
+    private final Component tip;
 
-    public Tip(int priority, String tip) {
+    public Tip(int priority, Component tip) {
         this.priority = priority;
         this.tip = tip;
     }
 
-    public String getTip() {
+    public Component getTip() {
         return tip;
     }
 
@@ -49,7 +51,7 @@ public class Tip {
             }
         }
 
-        return tips.get(0);
+        return tips.getFirst();
     }
 
     /**

--- a/src/main/java/org/braekpo1nt/mctmanager/games/event/states/HalftimeBreakState.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/event/states/HalftimeBreakState.java
@@ -21,6 +21,7 @@ public class HalftimeBreakState extends WaitingInHubState {
                 .titleAudience(Audience.audience(context.getParticipants()))
                 .sidebarPrefix(Component.text("Break: ").color(NamedTextColor.YELLOW))
                 .onCompletion(() -> {
+                    cancelAllTasks();
                     gameManager.removeParticipantsFromHub(context.getParticipants());
                     context.setState(new WaitingInHubState(context));
                 })

--- a/src/main/java/org/braekpo1nt/mctmanager/games/event/states/HalftimeBreakState.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/event/states/HalftimeBreakState.java
@@ -21,7 +21,7 @@ public class HalftimeBreakState extends WaitingInHubState {
                 .titleAudience(Audience.audience(context.getParticipants()))
                 .sidebarPrefix(Component.text("Break: ").color(NamedTextColor.YELLOW))
                 .onCompletion(() -> {
-                    cancelAllTasks();
+                    context.getPlugin().getServer().getScheduler().cancelTask(actionBarTaskId);
                     gameManager.removeParticipantsFromHub(context.getParticipants());
                     context.setState(new WaitingInHubState(context));
                 })

--- a/src/main/java/org/braekpo1nt/mctmanager/games/event/states/HalftimeBreakState.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/event/states/HalftimeBreakState.java
@@ -21,7 +21,9 @@ public class HalftimeBreakState extends WaitingInHubState {
                 .titleAudience(Audience.audience(context.getParticipants()))
                 .sidebarPrefix(Component.text("Break: ").color(NamedTextColor.YELLOW))
                 .onCompletion(() -> {
-                    context.getPlugin().getServer().getScheduler().cancelTask(actionBarTaskId);
+                    for (Integer taskId : taskIds) {
+                        context.getPlugin().getServer().getScheduler().cancelTask(taskId);
+                    }
                     gameManager.removeParticipantsFromHub(context.getParticipants());
                     context.setState(new WaitingInHubState(context));
                 })

--- a/src/main/java/org/braekpo1nt/mctmanager/games/event/states/WaitingInHubState.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/event/states/WaitingInHubState.java
@@ -18,6 +18,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
+import org.bukkit.scheduler.BukkitScheduler;
 import org.bukkit.scheduler.BukkitTask;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -182,20 +183,22 @@ public class WaitingInHubState implements EventState {
         List<Tip> allTips = context.getConfig().getTips();
         int tipsDisplayTimeSeconds = context.getConfig().getTipsDisplayTimeSeconds();
 
+        BukkitScheduler scheduler = context.getPlugin().getServer().getScheduler();
+
         Map<String, List<Player>> teamMapping = context.getTeamToOnlinePlayersMapping();
 
-        actionBarTaskId = context.getPlugin().getServer().getScheduler().scheduleSyncRepeatingTask(context.getPlugin(), () -> {
+        actionBarTaskId = scheduler.scheduleSyncRepeatingTask(context.getPlugin(), () -> {
             for (List<Player> teamPlayers : teamMapping.values()) {
                 List<Tip> tips = Tip.selectMultipleWeightedRandomTips(allTips, teamPlayers.size());
 
                 for (int i = 0; i < teamPlayers.size(); i++) {
                     Player player = teamPlayers.get(i);
-                    String tip = tips.get(i).getTip();
+                    Component tip = tips.get(i).getTip();
 
-                    BukkitTask task = Bukkit.getScheduler().runTaskTimer(context.getPlugin(), () -> {
-                        player.sendActionBar(Component.text(tip).color(NamedTextColor.GOLD));
+                    BukkitTask task = scheduler.runTaskTimer(context.getPlugin(), () -> {
+                        player.sendActionBar(tip);
                     }, 0L, 20L);
-                    Bukkit.getScheduler().runTaskLater(context.getPlugin(), task::cancel,
+                    scheduler.runTaskLater(context.getPlugin(), task::cancel,
                             tipsDisplayTimeSeconds * 20L);
                 }
             }

--- a/src/main/resources/org/braekpo1nt/mctmanager/games/event/config/exampleEventConfig.json
+++ b/src/main/resources/org/braekpo1nt/mctmanager/games/event/config/exampleEventConfig.json
@@ -15,5 +15,50 @@
     "voting": 20,
     "startingGame": 5,
     "backToHub": 10
+  },
+  "tips": {
+    "displayTimeSeconds": 5,
+    "tips": [
+      {
+        "text": "Work together as a team for maximum points!",
+        "priority": 1
+      },
+      {
+        "text": "Communication is key to victory!",
+        "priority": 2
+      },
+      {
+        "text": "Don't forget to use your abilities strategically!",
+        "priority": 5
+      },
+      {
+        "text": "Keep an eye on the scoreboard – the competition is fierce!",
+        "priority": 3
+      },
+      {
+        "text": "Explore the map to find hidden advantages!",
+        "priority": 2
+      },
+      {
+        "text": "Teamwork makes the dream work!",
+        "priority": 1
+      },
+      {
+        "text": "Use the environment to your advantage!",
+        "priority": 2
+      },
+      {
+        "text": "Every point counts!",
+        "priority": 3
+      },
+      {
+        "text": "Good luck, and have fun!",
+        "priority": 1
+      },
+      {
+        "text": "May the odds be ever in your favor!",
+        "priority": 1
+      }
+    ]
   }
 }

--- a/src/main/resources/org/braekpo1nt/mctmanager/games/event/config/exampleEventConfig.json
+++ b/src/main/resources/org/braekpo1nt/mctmanager/games/event/config/exampleEventConfig.json
@@ -20,43 +20,85 @@
     "displayTimeSeconds": 5,
     "tips": [
       {
-        "text": "Work together as a team for maximum points!",
+        "text": {
+          "text": "Work together as a team for maximum points!",
+          "color": "gold",
+          "bold": true
+        },
         "priority": 1
       },
       {
-        "text": "Communication is key to victory!",
+        "text": {
+          "text": "Communication is key to victory!",
+          "color": "aqua",
+          "italic": true
+        },
         "priority": 2
       },
       {
-        "text": "Don't forget to use your abilities strategically!",
+        "text": {
+          "text": "Don't forget to use your abilities strategically!",
+          "color": "red",
+          "bold": true,
+          "italic": true
+        },
         "priority": 5
       },
       {
-        "text": "Keep an eye on the scoreboard – the competition is fierce!",
+        "text": {
+          "text": "Keep an eye on the scoreboard – the competition is fierce!",
+          "color": "green",
+          "underlined": true
+        },
         "priority": 3
       },
       {
-        "text": "Explore the map to find hidden advantages!",
+        "text": {
+          "text": "Explore the map to find hidden advantages!",
+          "color": "light_purple",
+          "italic": true
+        },
         "priority": 2
       },
       {
-        "text": "Teamwork makes the dream work!",
+        "text": {
+          "text": "Teamwork makes the dream work!",
+          "color": "blue",
+          "bold": true
+        },
         "priority": 1
       },
       {
-        "text": "Use the environment to your advantage!",
+        "text": {
+          "text": "Use the environment to your advantage!",
+          "color": "yellow",
+          "underlined": true
+        },
         "priority": 2
       },
       {
-        "text": "Every point counts!",
+        "text": {
+          "text": "Every point counts!",
+          "color": "dark_green",
+          "bold": true
+        },
         "priority": 3
       },
       {
-        "text": "Good luck, and have fun!",
+        "text": {
+          "text": "Good luck, and have fun!",
+          "color": "dark_aqua",
+          "italic": true
+        },
         "priority": 1
       },
       {
-        "text": "May the odds be ever in your favor!",
+        "text": {
+          "text": "May the odds be ever in your favor!",
+          "color": "dark_purple",
+          "bold": true,
+          "italic": true
+        },
         "priority": 1
       }
     ]


### PR DESCRIPTION
Closes #632 

Allows for tip configuration in the `eventConfig.json` file, consisting of tips, each with a given priority, and the display duration per tip.

`GameState` and `EventManager` were modified to include a function that returns a mapping from teams to players, to show each team their own set of (non-overlapping) tips. 

Created a class in `Tip.java` that contains the data of a tip and provides a method to fetch a subset of tips of a given size based on the priority of the tips.

The main logic can be found in `WaitingInHubState.java`, in the method `startActionBarTips`.