### PR TITLE
Add /bugreport and /notready Commands (#629)

### DIFF
--- a/src/main/java/org/braekpo1nt/mctmanager/Main.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/Main.java
@@ -39,7 +39,7 @@ import java.util.logging.Logger;
 public class Main extends JavaPlugin {
 
     public static final List<String> VALID_CONFIG_VERSIONS = List.of("0.1.0", "0.1.1", "0.1.2");
-
+    
     /**
      * A default Gson instance for general use
      */
@@ -50,37 +50,32 @@ public class Main extends JavaPlugin {
     public static final Gson GSON_PRETTY = new GsonBuilder().setPrettyPrinting().create();
     private GameManager gameManager;
     private boolean saveGameStateOnDisable = true;
-    public final static PotionEffect NIGHT_VISION = new PotionEffect(PotionEffectType.NIGHT_VISION, 300, 3, true, false,
-            false);
+    public final static PotionEffect NIGHT_VISION = new PotionEffect(PotionEffectType.NIGHT_VISION, 300, 3, true, false, false);
     private MCTCommand mctCommand;
     /**
-     * This should be the application-wide logger used to print logs to the console
-     * or standard out.
-     * Initialized to Lombok log value so that tests don't trigger
-     * NullPointerExceptions
+     * This should be the application-wide logger used to print logs to the console or standard out. 
+     * Initialized to Lombok log value so that tests don't trigger NullPointerExceptions
      */
     private static Logger logger = log;
     private static final Map<LogType, @NotNull Boolean> logTypeActive = new HashMap<>();
-
+    
     protected GameManager initialGameManager(Scoreboard mctScoreboard) {
         return new GameManager(this, mctScoreboard);
     }
-
+    
     /**
      * @return the plugin's logger
      */
     public static Logger logger() {
         return Main.logger;
     }
-
+    
     public static void setLogTypeActive(@NotNull LogType logType, boolean active) {
         logTypeActive.put(logType, active);
     }
-
+    
     /**
-     * Logs the message if the given {@link LogType} should be logged (as determined
-     * by {@link #logTypeActive})
-     * 
+     * Logs the message if the given {@link LogType} should be logged (as determined by {@link #logTypeActive})
      * @param logType the {@link LogType} of the message
      * @param message the message to log
      * @see #setLogTypeActive(LogType, boolean)
@@ -90,47 +85,42 @@ public class Main extends JavaPlugin {
             Main.logger().info(message);
         }
     }
-
+    
     /**
-     * Logs the message if the given {@link LogType} should be logged (as determined
-     * by {@link #logTypeActive})
-     * 
+     * Logs the message if the given {@link LogType} should be logged (as determined by {@link #logTypeActive})
      * @param logType the {@link LogType} of the message
-     * @param message the message to log.
-     *                Must be a valid {@link Logger#log(Level, String, Object[])}
-     *                string.
+     * @param message the message to log. 
+     *                Must be a valid {@link Logger#log(Level, String, Object[])} string. 
      *                The provided args will be used as the {code Object...}
      *                arguments of the format string.
-     * @param args    the args the arguments of the
-     *                {@link Logger#log(Level, String, Object[])} which
-     *                uses the message as the pattern.
+     * @param args the args the arguments of the {@link Logger#log(Level, String, Object[])} which 
+     *             uses the message as the pattern.
      */
     public static void debugLog(@NotNull LogType logType, @NotNull String message, Object... args) {
         if (logTypeActive.get(logType)) {
             Main.logger.log(Level.INFO, message, args);
         }
     }
-
+    
     @Override
     public void onLoad() {
         PacketEvents.setAPI(SpigotPacketEventsBuilder.build(this));
         PacketEvents.getAPI().load();
     }
-
+    
     @Override
     public void onEnable() {
         Main.logger = this.getLogger();
         Scoreboard mctScoreboard = Bukkit.getScoreboardManager().getNewScoreboard();
-        ParticipantInitializer.setPlugin(this); // TODO: remove this in favor of death and respawn combination
-
+        ParticipantInitializer.setPlugin(this); //TODO: remove this in favor of death and respawn combination 
+        
         PacketEvents.getAPI().init();
-
+        
         gameManager = initialGameManager(mctScoreboard);
         try {
             gameManager.loadHubConfig();
         } catch (ConfigException e) {
-            Main.logger().severe(String.format("[MCTManager] Could not load hub config, see console for details. %s",
-                    e.getMessage()));
+            Main.logger().severe(String.format("[MCTManager] Could not load hub config, see console for details. %s", e.getMessage()));
             e.printStackTrace();
             saveGameStateOnDisable = false;
             Bukkit.getPluginManager().disablePlugin(this);
@@ -143,10 +133,10 @@ public class Main extends JavaPlugin {
             Bukkit.getPluginManager().disablePlugin(this);
             return;
         }
-
+        
         // Listeners
         BlockEffectsListener blockEffectsListener = new BlockEffectsListener(this);
-
+        
         // Commands
         new MCTDebugCommand(this);
         mctCommand = new MCTCommand(this, gameManager, blockEffectsListener);
@@ -157,14 +147,14 @@ public class Main extends JavaPlugin {
         new TeamMsgCommand(this, gameManager);
         new BugReportCommand(this, gameManager);
         new NotReadyCommand(this, gameManager);
-
+    
         alwaysGiveNightVision();
     }
-
+    
     public MCTCommand getMctCommand() {
         return mctCommand;
     }
-
+    
     private void alwaysGiveNightVision() {
         Main.logger().info("[MCTManager] Night vision activated");
         new BukkitRunnable() {
@@ -176,10 +166,10 @@ public class Main extends JavaPlugin {
             }
         }.runTaskTimer(this, 0L, 60L);
     }
-
+    
     @Override
     public void onDisable() {
-        ParticipantInitializer.setPlugin(null); // TODO: remove this in favor of death and respawn combination
+        ParticipantInitializer.setPlugin(null); //TODO: remove this in favor of death and respawn combination 
         PacketEvents.getAPI().terminate();
         if (saveGameStateOnDisable && gameManager != null) {
             gameManager.cancelVote();
@@ -201,9 +191,9 @@ public class Main extends JavaPlugin {
             Main.logger().info("[MCTManager] Skipping save game state.");
         }
     }
-
+    
     // Testing methods for mocking components
-
+    
     public GameManager getGameManager() {
         return gameManager;
     }

--- a/src/main/java/org/braekpo1nt/mctmanager/Main.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/Main.java
@@ -5,6 +5,8 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import io.github.retrooper.packetevents.factory.spigot.SpigotPacketEventsBuilder;
 import lombok.extern.java.Log;
+
+import org.braekpo1nt.mctmanager.commands.bugreport.BugReportCommand;
 import org.braekpo1nt.mctmanager.commands.dynamic.top.TopCommand;
 import org.braekpo1nt.mctmanager.commands.mct.MCTCommand;
 import org.braekpo1nt.mctmanager.commands.mctdebug.MCTDebugCommand;
@@ -36,7 +38,7 @@ import java.util.logging.Logger;
 public class Main extends JavaPlugin {
 
     public static final List<String> VALID_CONFIG_VERSIONS = List.of("0.1.0", "0.1.1", "0.1.2");
-    
+
     /**
      * A default Gson instance for general use
      */
@@ -47,32 +49,37 @@ public class Main extends JavaPlugin {
     public static final Gson GSON_PRETTY = new GsonBuilder().setPrettyPrinting().create();
     private GameManager gameManager;
     private boolean saveGameStateOnDisable = true;
-    public final static PotionEffect NIGHT_VISION = new PotionEffect(PotionEffectType.NIGHT_VISION, 300, 3, true, false, false);
+    public final static PotionEffect NIGHT_VISION = new PotionEffect(PotionEffectType.NIGHT_VISION, 300, 3, true, false,
+            false);
     private MCTCommand mctCommand;
     /**
-     * This should be the application-wide logger used to print logs to the console or standard out. 
-     * Initialized to Lombok log value so that tests don't trigger NullPointerExceptions
+     * This should be the application-wide logger used to print logs to the console
+     * or standard out.
+     * Initialized to Lombok log value so that tests don't trigger
+     * NullPointerExceptions
      */
     private static Logger logger = log;
     private static final Map<LogType, @NotNull Boolean> logTypeActive = new HashMap<>();
-    
+
     protected GameManager initialGameManager(Scoreboard mctScoreboard) {
         return new GameManager(this, mctScoreboard);
     }
-    
+
     /**
      * @return the plugin's logger
      */
     public static Logger logger() {
         return Main.logger;
     }
-    
+
     public static void setLogTypeActive(@NotNull LogType logType, boolean active) {
         logTypeActive.put(logType, active);
     }
-    
+
     /**
-     * Logs the message if the given {@link LogType} should be logged (as determined by {@link #logTypeActive})
+     * Logs the message if the given {@link LogType} should be logged (as determined
+     * by {@link #logTypeActive})
+     * 
      * @param logType the {@link LogType} of the message
      * @param message the message to log
      * @see #setLogTypeActive(LogType, boolean)
@@ -82,42 +89,47 @@ public class Main extends JavaPlugin {
             Main.logger().info(message);
         }
     }
-    
+
     /**
-     * Logs the message if the given {@link LogType} should be logged (as determined by {@link #logTypeActive})
+     * Logs the message if the given {@link LogType} should be logged (as determined
+     * by {@link #logTypeActive})
+     * 
      * @param logType the {@link LogType} of the message
-     * @param message the message to log. 
-     *                Must be a valid {@link Logger#log(Level, String, Object[])} string. 
+     * @param message the message to log.
+     *                Must be a valid {@link Logger#log(Level, String, Object[])}
+     *                string.
      *                The provided args will be used as the {code Object...}
      *                arguments of the format string.
-     * @param args the args the arguments of the {@link Logger#log(Level, String, Object[])} which 
-     *             uses the message as the pattern.
+     * @param args    the args the arguments of the
+     *                {@link Logger#log(Level, String, Object[])} which
+     *                uses the message as the pattern.
      */
     public static void debugLog(@NotNull LogType logType, @NotNull String message, Object... args) {
         if (logTypeActive.get(logType)) {
             Main.logger.log(Level.INFO, message, args);
         }
     }
-    
+
     @Override
     public void onLoad() {
         PacketEvents.setAPI(SpigotPacketEventsBuilder.build(this));
         PacketEvents.getAPI().load();
     }
-    
+
     @Override
     public void onEnable() {
         Main.logger = this.getLogger();
         Scoreboard mctScoreboard = Bukkit.getScoreboardManager().getNewScoreboard();
-        ParticipantInitializer.setPlugin(this); //TODO: remove this in favor of death and respawn combination 
-        
+        ParticipantInitializer.setPlugin(this); // TODO: remove this in favor of death and respawn combination
+
         PacketEvents.getAPI().init();
-        
+
         gameManager = initialGameManager(mctScoreboard);
         try {
             gameManager.loadHubConfig();
         } catch (ConfigException e) {
-            Main.logger().severe(String.format("[MCTManager] Could not load hub config, see console for details. %s", e.getMessage()));
+            Main.logger().severe(String.format("[MCTManager] Could not load hub config, see console for details. %s",
+                    e.getMessage()));
             e.printStackTrace();
             saveGameStateOnDisable = false;
             Bukkit.getPluginManager().disablePlugin(this);
@@ -130,10 +142,10 @@ public class Main extends JavaPlugin {
             Bukkit.getPluginManager().disablePlugin(this);
             return;
         }
-        
+
         // Listeners
         BlockEffectsListener blockEffectsListener = new BlockEffectsListener(this);
-        
+
         // Commands
         new MCTDebugCommand(this);
         mctCommand = new MCTCommand(this, gameManager, blockEffectsListener);
@@ -142,14 +154,15 @@ public class Main extends JavaPlugin {
         new UnReadyCommand(this, gameManager);
         new TopCommand(this, gameManager);
         new TeamMsgCommand(this, gameManager);
-    
+        new BugReportCommand(this, gameManager);
+
         alwaysGiveNightVision();
     }
-    
+
     public MCTCommand getMctCommand() {
         return mctCommand;
     }
-    
+
     private void alwaysGiveNightVision() {
         Main.logger().info("[MCTManager] Night vision activated");
         new BukkitRunnable() {
@@ -161,10 +174,10 @@ public class Main extends JavaPlugin {
             }
         }.runTaskTimer(this, 0L, 60L);
     }
-    
+
     @Override
     public void onDisable() {
-        ParticipantInitializer.setPlugin(null); //TODO: remove this in favor of death and respawn combination 
+        ParticipantInitializer.setPlugin(null); // TODO: remove this in favor of death and respawn combination
         PacketEvents.getAPI().terminate();
         if (saveGameStateOnDisable && gameManager != null) {
             gameManager.cancelVote();
@@ -186,9 +199,9 @@ public class Main extends JavaPlugin {
             Main.logger().info("[MCTManager] Skipping save game state.");
         }
     }
-    
+
     // Testing methods for mocking components
-    
+
     public GameManager getGameManager() {
         return gameManager;
     }

--- a/src/main/java/org/braekpo1nt/mctmanager/Main.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/Main.java
@@ -10,6 +10,7 @@ import org.braekpo1nt.mctmanager.commands.bugreport.BugReportCommand;
 import org.braekpo1nt.mctmanager.commands.dynamic.top.TopCommand;
 import org.braekpo1nt.mctmanager.commands.mct.MCTCommand;
 import org.braekpo1nt.mctmanager.commands.mctdebug.MCTDebugCommand;
+import org.braekpo1nt.mctmanager.commands.notready.NotReadyCommand;
 import org.braekpo1nt.mctmanager.commands.readyup.ReadyUpCommand;
 import org.braekpo1nt.mctmanager.commands.readyup.UnReadyCommand;
 import org.braekpo1nt.mctmanager.commands.teammsg.TeamMsgCommand;
@@ -155,6 +156,7 @@ public class Main extends JavaPlugin {
         new TopCommand(this, gameManager);
         new TeamMsgCommand(this, gameManager);
         new BugReportCommand(this, gameManager);
+        new NotReadyCommand(this, gameManager);
 
         alwaysGiveNightVision();
     }

--- a/src/main/java/org/braekpo1nt/mctmanager/commands/bugreport/BugReportCommand.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/commands/bugreport/BugReportCommand.java
@@ -13,6 +13,7 @@ import org.bukkit.command.TabExecutor;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.title.Title;
@@ -41,15 +42,14 @@ public class BugReportCommand implements TabExecutor {
 
         String description = String.join(" ", args);
 
-        gameManager.playSoundForAdmins(Sound.BLOCK_NOTE_BLOCK_PLING.name().toLowerCase(), 1, 1);
-        gameManager.getOnlineAdmins().forEach(admin -> {
-            admin.showTitle(Title.title(
-                    Component.text(""),
-                    Component.text(sender.getName() + " reported a bug")));
-        });
+        gameManager.playSoundForAdmins(Sound.BLOCK_NOTE_BLOCK_PLING.key().value(), 1, 1);
+        Audience.audience(gameManager.getOnlineAdmins()).showTitle(Title.title(
+            Component.text(""),
+            Component.text(sender.getName() + " reported a bug")));
 
         // TODO: Logs the bug and the timestamp to a file
         Main.logger().warning(sender.getName() + "reported a bug: " + description);
+        gameManager.messageAdmins(Component.text(sender.getName() + "reported a bug: " + description));
 
         return true;
     }

--- a/src/main/java/org/braekpo1nt/mctmanager/commands/bugreport/BugReportCommand.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/commands/bugreport/BugReportCommand.java
@@ -1,0 +1,62 @@
+package org.braekpo1nt.mctmanager.commands.bugreport;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.braekpo1nt.mctmanager.Main;
+import org.braekpo1nt.mctmanager.games.GameManager;
+import org.bukkit.Sound;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.PluginCommand;
+import org.bukkit.command.TabExecutor;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.title.Title;
+
+public class BugReportCommand implements TabExecutor {
+    private final GameManager gameManager;
+
+    public BugReportCommand(Main plugin, GameManager gameManager) {
+        PluginCommand command = plugin.getCommand("bugreport");
+        this.gameManager = gameManager;
+        if (command == null) {
+            Main.logger().severe("Unable to find the /bugreport command in plugin.yml");
+            return;
+        }
+        command.setExecutor(this);
+    }
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label,
+            @NotNull String[] args) {
+
+        if (args.length == 0) {
+            sender.sendMessage(Component.text("Usage: /bugreport <description>", NamedTextColor.RED));
+            return true;
+        }
+
+        String description = String.join(" ", args);
+
+        gameManager.playSoundForAdmins(Sound.BLOCK_NOTE_BLOCK_PLING.name().toLowerCase(), 1, 1);
+        gameManager.getOnlineAdmins().forEach(admin -> {
+            admin.showTitle(Title.title(
+                    Component.text(""),
+                    Component.text(sender.getName() + " reported a bug")));
+        });
+
+        // TODO: Logs the bug and the timestamp to a file
+        Main.logger().warning(description);
+
+        return true;
+    }
+
+    @Override
+    public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command,
+            @NotNull String label, @NotNull String[] args) {
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/org/braekpo1nt/mctmanager/commands/bugreport/BugReportCommand.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/commands/bugreport/BugReportCommand.java
@@ -49,7 +49,7 @@ public class BugReportCommand implements TabExecutor {
         });
 
         // TODO: Logs the bug and the timestamp to a file
-        Main.logger().warning(description);
+        Main.logger().warning(sender.getName() + "reported a bug: " + description);
 
         return true;
     }

--- a/src/main/java/org/braekpo1nt/mctmanager/commands/notready/NotReadyCommand.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/commands/notready/NotReadyCommand.java
@@ -13,6 +13,7 @@ import org.bukkit.command.TabExecutor;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.title.Title;
@@ -41,12 +42,10 @@ public class NotReadyCommand implements TabExecutor {
 
         String reason = String.join(" ", args);
 
-        gameManager.playSoundForAdmins(Sound.BLOCK_NOTE_BLOCK_PLING.name().toLowerCase(), 1, 1);
-        gameManager.getOnlineAdmins().forEach(admin -> {
-            admin.showTitle(Title.title(
-                    Component.text(""),
-                    Component.text(sender.getName() + " is not ready to continue the event")));
-        });
+        gameManager.playSoundForAdmins(Sound.BLOCK_NOTE_BLOCK_PLING.key().value(), 1, 1);
+        Audience.audience(gameManager.getOnlineAdmins()).showTitle(Title.title(
+            Component.text(""),
+            Component.text(sender.getName() + " is not ready to continue the event")));
         gameManager.messageAdmins(
                 Component.text(sender.getName() + " is not ready to continue the event. Reason: " + reason));
 

--- a/src/main/java/org/braekpo1nt/mctmanager/commands/notready/NotReadyCommand.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/commands/notready/NotReadyCommand.java
@@ -1,0 +1,61 @@
+package org.braekpo1nt.mctmanager.commands.notready;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.braekpo1nt.mctmanager.Main;
+import org.braekpo1nt.mctmanager.games.GameManager;
+import org.bukkit.Sound;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.PluginCommand;
+import org.bukkit.command.TabExecutor;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.title.Title;
+
+public class NotReadyCommand implements TabExecutor {
+    private final GameManager gameManager;
+
+    public NotReadyCommand(Main plugin, GameManager gameManager) {
+        PluginCommand command = plugin.getCommand("notready");
+        this.gameManager = gameManager;
+        if (command == null) {
+            Main.logger().severe("Unable to find the /notready command in plugin.yml");
+            return;
+        }
+        command.setExecutor(this);
+    }
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label,
+            @NotNull String[] args) {
+
+        if (args.length == 0) {
+            sender.sendMessage(Component.text("Usage: /notready <reason>", NamedTextColor.RED));
+            return true;
+        }
+
+        String reason = String.join(" ", args);
+
+        gameManager.playSoundForAdmins(Sound.BLOCK_NOTE_BLOCK_PLING.name().toLowerCase(), 1, 1);
+        gameManager.getOnlineAdmins().forEach(admin -> {
+            admin.showTitle(Title.title(
+                    Component.text(""),
+                    Component.text(sender.getName() + " is not ready to continue the event")));
+        });
+        gameManager.messageAdmins(
+                Component.text(sender.getName() + " is not ready to continue the event. Reason: " + reason));
+
+        return true;
+    }
+
+    @Override
+    public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command,
+            @NotNull String label, @NotNull String[] args) {
+        return Collections.emptyList();
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -41,4 +41,7 @@ commands:
     permission-message: "You do not have permission to use this command"
   bugreport:
     description: Report a bug
-    usage: "/bugreport <options>"
+    usage: "/bugreport <description>"
+  notready:
+    description: Indicate your are not ready for the event to continue
+    usage: "/notready <reason>"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -42,6 +42,10 @@ commands:
   bugreport:
     description: Report a bug
     usage: "/bugreport <description>"
+    permission: mctmanager.bugreport
+    permission-message: "You do not have permission to use this command"
   notready:
     description: Indicate your are not ready for the event to continue
     usage: "/notready <reason>"
+    permission: mctmanager.notready
+    permission-message: "You do not have permission to use this command"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -39,3 +39,6 @@ commands:
     description: Send a message to your teammates
     permission: mctmanager.t
     permission-message: "You do not have permission to use this command"
+  bugreport:
+    description: Report a bug
+    usage: "/bugreport <options>"


### PR DESCRIPTION
This PR implements the `/bugreport` and `/notready` commands as requested in issue #629.

- **`/bugreport` command:**
  - Notifies admins immediately that a player has reported a bug.
  - Logs the bug.
  - Triggers a sound notification for admins.
  - Displays an on-screen subtitle-style message to alert admins.

- **`/notready` command:**
  - Lets players indicate they are not ready to proceed (e.g., crash, interruption).
  - Triggers a sound notification for admins.
  - Displays an on-screen subtitle-style message to alert admins.