### PR TITLE
830 use CompletableFuture for database interactions

### DIFF
--- a/src/main/java/org/braekpo1nt/mctmanager/Main.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/Main.java
@@ -49,6 +49,10 @@ import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -65,6 +69,18 @@ public class Main extends JavaPlugin {
      * A pretty printing Gson instance for general use
      */
     public static final Gson GSON_PRETTY = new GsonBuilder().setPrettyPrinting().create();
+    /**
+     * Used for thread-save operations like database queries.
+     * Bukkit operations which must be performed on the main thread must not
+     * be executed by this thread executor.
+     */
+    protected @Nullable ExecutorService databaseExecutor;
+    /**
+     * Bukkit operations which must be performed on the main thread (such as
+     * teleportation, block state changes, and world changes) can be safely executed
+     * on this thread executor.
+     */
+    protected @Nullable Executor mainThreadExecutor;
     protected GameManager gameManager;
     protected Database database;
     public final static PotionEffect NIGHT_VISION = new PotionEffect(PotionEffectType.NIGHT_VISION, 300, 3, true, false, false);
@@ -82,14 +98,18 @@ public class Main extends JavaPlugin {
                 databaseMode,
                 database
         );
+        if (mainThreadExecutor == null) {
+            throw new IllegalStateException("mainThreadExecutor can't be null");
+        }
         return new GameManager(
                 this,
                 mctScoreboard,
-                new GameStateStorageUtil(getLogger(), gameStateService),
+                new GameStateStorageUtil(getLogger(), gameStateService, database.getDatabaseExecutor()),
                 new SidebarFactory(),
                 config,
                 database,
-                gameStateService);
+                gameStateService,
+                mainThreadExecutor);
     }
     
     /**
@@ -152,6 +172,9 @@ public class Main extends JavaPlugin {
         Scoreboard mctScoreboard = this.getServer().getScoreboardManager().getNewScoreboard();
         ParticipantInitializer.setPlugin(this); //TODO: remove this in favor of death and respawn combination 
         
+        this.databaseExecutor = createDatabaseExecutor();
+        this.mainThreadExecutor = createMainThreadExecutor();
+        
         saveDefaultConfig();
         
         PacketEvents.getAPI().init();
@@ -190,6 +213,56 @@ public class Main extends JavaPlugin {
         alwaysGiveNightVision();
     }
     
+    /**
+     * Enables tests to nullify this easily
+     * @return the executor used for the database
+     */
+    protected @NotNull ExecutorService createDatabaseExecutor() {
+        return Executors.newFixedThreadPool(
+                4,
+                r -> {
+                    Thread thread = new Thread(r);
+                    thread.setName("mctmanager-db-worker");
+                    thread.setDaemon(true);
+                    return thread;
+                });
+    }
+    
+    /**
+     * Enables tests to make this a trivial executor
+     * @return the executor to use for the main thread. Non-thread-safe Bukkit operations
+     * may be run by this executor, such as teleport and block state changes.
+     */
+    protected @NotNull Executor createMainThreadExecutor() {
+        return this.getServer().getScheduler().getMainThreadExecutor(this);
+    }
+    
+    /**
+     * @return Bukkit operations which must be performed on the main thread (such as
+     * teleportation, block state changes, and world changes) can be safely executed
+     * on this thread executor.
+     */
+    public @NotNull Executor getMainThreadExecutor() {
+        if (this.mainThreadExecutor == null) {
+            this.mainThreadExecutor = createMainThreadExecutor();
+        }
+        return this.mainThreadExecutor;
+    }
+    
+    /**
+     * // TODO: is this how the executor should be used?
+     * @deprecated not sure if this is how callers should get their executor. Temporary.
+     * May want to ensure that the databaseExecutor can never be null, and mock the service
+     * in tests.
+     */
+    @Deprecated
+    public @NotNull Executor getDatabaseExecutor() {
+        if (this.databaseExecutor == null) {
+            this.databaseExecutor = createDatabaseExecutor();
+        }
+        return this.databaseExecutor;
+    }
+    
     protected Database setupDatabase() throws SQLException {
         String host = getConfig().getString("database.host", "localhost");
         String port = getConfig().getString("database.port", "3306");
@@ -200,12 +273,17 @@ public class Main extends JavaPlugin {
         String jdbcUrl = String.format("jdbc:mysql://%s:%s/%s", host, port, databaseName);
         flywayMigration(jdbcUrl, user, password, "ENGINE=InnoDB", "AUTO_INCREMENT", baselineOnMigrate);
         
+        if (databaseExecutor == null) {
+            throw new IllegalStateException("databaseExecutor can't be null");
+        }
+        
         return new Database(
                 host,
                 port,
                 user,
                 password,
-                databaseName
+                databaseName,
+                databaseExecutor
         );
     }
     
@@ -326,6 +404,7 @@ public class Main extends JavaPlugin {
     public void onDisable() {
         ParticipantInitializer.setPlugin(null); //TODO: remove this in favor of death and respawn combination 
         PacketEvents.getAPI().terminate();
+        // TODO: some of these methods return CompletableFutures, handle these in order
         if (gameManager != null) {
             if (gameManager.eventIsActive()) {
                 gameManager.stopEvent();
@@ -349,6 +428,18 @@ public class Main extends JavaPlugin {
             }
         } catch (Exception e) {
             getLogger().log(Level.SEVERE, "Error closing the database on plugin disable", e);
+        }
+        if (databaseExecutor != null) {
+            databaseExecutor.shutdown();
+            
+            try {
+                if (!databaseExecutor.awaitTermination(5, TimeUnit.SECONDS)) {
+                    databaseExecutor.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                databaseExecutor.shutdownNow();
+                Thread.currentThread().interrupt();
+            }
         }
     }
     

--- a/src/main/java/org/braekpo1nt/mctmanager/commands/CommandUtils.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/commands/CommandUtils.java
@@ -24,13 +24,6 @@ import java.util.stream.Collectors;
 public class CommandUtils {
     
     /**
-     * @deprecated remove this, no longer used
-     */
-    @Deprecated
-    private static final Map<String, List<String>> GAME_CONFIGS = new HashMap<>();
-    private static @NotNull List<String> PRESET_FILES = Collections.emptyList();
-    
-    /**
      * @param value the string to check if it is an integer
      * @return true if the string is an integer, false if not
      */
@@ -100,43 +93,6 @@ public class CommandUtils {
         return list.stream().filter(s -> s.toLowerCase().startsWith(lowerCasePartial)).toList();
     }
     
-    /**
-     * List the config files in the directory for the given gameID
-     * @param gameID the gameID to get the configs for
-     * @return the configs associated with that gameID, or an empty list
-     * if none are found
-     * @deprecated use {@link #getGameConfigs(Main, GameType)}
-     */
-    @Deprecated
-    public static @NotNull List<String> getGameConfigs(@NotNull String gameID) {
-        return GAME_CONFIGS.getOrDefault(gameID, Collections.emptyList());
-    }
-    
-    /**
-     * Searches the plugin's data folder asynchronously to store
-     * references to each game's config folder and the json config
-     * files contained within, enabling cheap tab completion.
-     * @param plugin enables asynchronous file IO
-     * @deprecated use {@link #getGameConfigs(Main, GameType)}
-     */
-    @Deprecated
-    public static void refreshGameConfigs(Main plugin) {
-        plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
-            for (String gameID : GameType.GAME_IDS.keySet()) {
-                File configDir = new File(plugin.getDataFolder(), gameID);
-                if (configDir.isDirectory()) {
-                    File[] jsonFiles = configDir.listFiles(file ->
-                            file.isFile() && file.getName().endsWith(".json"));
-                    if (jsonFiles != null) {
-                        GAME_CONFIGS.put(gameID, Arrays.stream(jsonFiles)
-                                .map(File::getName)
-                                .toList());
-                    }
-                }
-            }
-        });
-    }
-    
     public static @NotNull List<String> getGameConfigs(@NotNull Main plugin, @NotNull GameType gameId) {
         File configDir = new File(plugin.getDataFolder(), gameId.getId());
         if (configDir.isDirectory()) {
@@ -149,35 +105,6 @@ public class CommandUtils {
             }
         }
         return Collections.emptyList();
-    }
-    
-    public static CompletableFuture<Suggestions> suggestConfigFiles(@NotNull Main plugin, CommandContext<CommandSourceStack> ctx, SuggestionsBuilder builder) {
-        return CompletableFuture.supplyAsync(() -> {
-            GameType gameId = ctx.getArgument("gameId", GameType.class);
-            getGameConfigs(plugin, gameId).stream()
-                    .filter(configFile -> configFile.startsWith(builder.getRemaining()))
-                    .forEach(builder::suggest);
-            return builder.build();
-        });
-    }
-    
-    public static @NotNull List<String> getPresetFiles() {
-        return PRESET_FILES;
-    }
-    
-    public static void refreshPresetFiles(Main plugin) {
-        plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
-            File configDir = new File(plugin.getDataFolder(), "presets");
-            if (configDir.isDirectory()) {
-                File[] jsonFiles = configDir.listFiles(file ->
-                        file.isFile() && file.getName().endsWith(".json"));
-                if (jsonFiles != null) {
-                    PRESET_FILES = Arrays.stream(jsonFiles)
-                            .map(File::getName)
-                            .toList();
-                }
-            }
-        });
     }
     
     public static @NotNull String[] removeElement(@NotNull String[] original, int indexToRemove) {
@@ -194,48 +121,6 @@ public class CommandUtils {
     // a few helpers for theoretical automatic permission node creation:
     
     //========================
-    
-    public static @NotNull Component displayCommandNodes(List<List<String>> allPermNodes) {
-        TextComponent.Builder builder = Component.text();
-        for (List<String> permNodes : allPermNodes) {
-            for (String permNode : permNodes) {
-                builder
-                        .append(Component.text(permNode))
-                        .append(Component.text("."));
-            }
-            builder.append(Component.newline());
-        }
-        return builder.build();
-    }
-    
-    public static List<List<String>> toPermNodes(CommandNode<CommandSourceStack> root) {
-        List<List<String>> result = new ArrayList<>();
-        Deque<String> path = new ArrayDeque<>();
-        
-        traverse(root, path, result);
-        
-        return result;
-    }
-    
-    private static void traverse(
-            CommandNode<CommandSourceStack> node,
-            Deque<String> path,
-            List<List<String>> result
-    ) {
-        // Add current node to path
-        path.addLast(node.getName());
-        
-        // Record current path
-        result.add(new ArrayList<>(path));
-        
-        // Traverse children
-        for (CommandNode<CommandSourceStack> child : node.getChildren()) {
-            traverse(child, path, result);
-        }
-        
-        // Backtrack
-        path.removeLast();
-    }
     
     public static CompletableFuture<Suggestions> suggestColor(CommandContext<CommandSourceStack> ctx, SuggestionsBuilder builder) {
         List<String> suggestions = ColorMap.getPartiallyMatchingColorStrings(builder.getRemainingLowerCase());

--- a/src/main/java/org/braekpo1nt/mctmanager/commands/argumenttypes/OfflineAdminArgumentType.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/commands/argumenttypes/OfflineAdminArgumentType.java
@@ -28,12 +28,13 @@ public class OfflineAdminArgumentType implements CustomArgumentType.Converted<Of
     
     @Override
     public <S> @NotNull CompletableFuture<Suggestions> listSuggestions(@NotNull CommandContext<S> context, @NotNull SuggestionsBuilder builder) {
-        return CompletableFuture.supplyAsync(() -> {
-            gameManager.getAllAdminNames().stream()
-                    .filter(name -> name.toLowerCase().startsWith(builder.getRemainingLowerCase()))
-                    .forEach(builder::suggest);
-            return builder.build();
-        });
+        return gameManager.getAllAdminNames()
+                .thenApply(names -> {
+                    names.stream()
+                            .filter(name -> name.toLowerCase().startsWith(builder.getRemainingLowerCase()))
+                            .forEach(builder::suggest);
+                    return builder.build();
+                });
     }
     
     @Override

--- a/src/main/java/org/braekpo1nt/mctmanager/commands/manager/commandresult/CommandResult.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/commands/manager/commandresult/CommandResult.java
@@ -1,14 +1,17 @@
 package org.braekpo1nt.mctmanager.commands.manager.commandresult;
 
+import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
 import org.braekpo1nt.mctmanager.Main;
 import org.braekpo1nt.mctmanager.commands.manager.Usage;
-import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.sql.SQLException;
+import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 
 public interface CommandResult {
@@ -37,21 +40,33 @@ public interface CommandResult {
         return new CompositeCommandResult(this, other);
     }
     
+    static <T extends Audience> void showResult(@NotNull Collection<T> senders, @NotNull CommandResult commandResult) {
+        Component message = commandResult.getMessage();
+        if (message != null) {
+            Audience.audience(senders).sendMessage(message);
+        }
+    }
+    
     /**
      * Convenience method for showing the message from a given {@link CommandResult}
      * @param sender the sender to show the result to
      * @param commandResult the {@link CommandResult} to get the {@link CommandResult#getMessage()} from
      */
-    static void showResult(@NotNull CommandSender sender, @NotNull CommandResult commandResult) {
+    static void showResult(@NotNull Audience sender, @NotNull CommandResult commandResult) {
         Component message = commandResult.getMessage();
         if (message != null) {
             sender.sendMessage(message);
         }
     }
     
-    static void showResult(@NotNull CommandSender sender, @NotNull CompletableFuture<CommandResult> completableFuture) {
+    static void showResult(@NotNull Audience sender, @NotNull CompletableFuture<CommandResult> completableFuture) {
         completableFuture
                 .thenAccept(asyncResult -> showResult(sender, asyncResult));
+    }
+    
+    static <T extends Audience> void showResult(@NotNull Collection<T> senders, @NotNull CompletableFuture<CommandResult> completableFuture) {
+        completableFuture
+                .thenAccept(asyncResult -> showResult(senders, asyncResult));
     }
     
     /**
@@ -106,7 +121,7 @@ public interface CommandResult {
      * @return this CommandResult as a {@link CompletableFuture<CommandResult>}
      */
     default CompletableFuture<CommandResult> asFuture() {
-        return CompletableFuture.supplyAsync(() -> this);
+        return CompletableFuture.completedFuture(this);
     }
     
     /**
@@ -115,7 +130,7 @@ public interface CommandResult {
      * @param tryingTo the attempted action, complete the sentence "A database error occurred trying to..." (no
      * trailing or leading spaces needed)
      * @param e the exception that occurred
-     * @return a {@link CommandResult} detailing the database error that occurred and
+     * @return a {@link CommandResult} detailing the database error that occurred
      */
     static @NotNull CommandResult sqlException(String tryingTo, SQLException e) {
         Main.logger().log(Level.SEVERE, String.format("A database error occurred trying to %s", tryingTo), e);
@@ -127,4 +142,45 @@ public interface CommandResult {
                 .append(Component.text(e.getMessage()))
         );
     }
+    
+    /**
+     * Convenience method to report that a {@link Throwable} occurred when running a command.
+     * Also logs the error to the console.
+     * @param tryingTo the attempted action, complete the sentence "An error occurred trying to..." (no
+     * trailing or leading spaces needed)
+     * @param e the throwable that occurred
+     * @return a {@link CommandResult} detailing the error that occurred
+     */
+    static @NotNull CommandResult throwable(String tryingTo, Throwable e) {
+        Main.logger().log(Level.SEVERE, String.format("An error occurred trying to %s", tryingTo), e);
+        return failure(Component.empty()
+                .append(Component.text("An error occurred trying to "))
+                .append(Component.text(tryingTo))
+                .append(Component.text(". See console for details"))
+                .append(Component.newline())
+                .append(Component.text(e.getMessage()))
+        );
+    }
+    
+    /**
+     * Convenience method to add a link in a chain of {@link CompletableFuture<CommandResult>}s
+     * which adds on a new result and passes the combined results to the next link in the chain.
+     * @param chain the previous {@link CompletableFuture<CommandResult>}
+     * @param operation the next {@link CompletableFuture<CommandResult>}
+     * @param executor the thread to execute on
+     * @param <T> a CommandResult implementation
+     * @return a new {@link CompletableFuture<CommandResult>} with the operation's result appended to
+     * the chain's result using {@link CommandResult#and(CommandResult)}
+     */
+    static <T extends CommandResult> CompletableFuture<CommandResult> appendAsync(
+            CompletableFuture<T> chain,
+            Supplier<CompletableFuture<T>> operation,
+            Executor executor
+    ) {
+        return chain.thenComposeAsync(
+                result -> operation.get().thenApply(result::and),
+                executor
+        );
+    }
+    
 }

--- a/src/main/java/org/braekpo1nt/mctmanager/commands/mct/MCTCommand.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/commands/mct/MCTCommand.java
@@ -38,7 +38,7 @@ public class MCTCommand implements BrigadierCommand {
     @Override
     public LiteralCommandNode<CommandSourceStack> build() {
         return Permissioned.literal("mct")
-                .then(new EventCommand(gameManager, plugin).create())
+                .then(new EventCommand(gameManager).create())
                 .then(new TeamCommand(plugin, gameManager).create())
                 .then(new AdminCommand(gameManager).create())
                 .then(new DebugCommand().create())
@@ -51,7 +51,7 @@ public class MCTCommand implements BrigadierCommand {
                 .then(new TabListCommand(gameManager).create())
                 .then(new TimerCommand(gameManager).create())
                 .then(Permissioned.literal("load")
-                        .executes(BrigadierAdapters.wraps(ctx -> gameManager.loadGameState()))
+                        .executes(BrigadierAdapters.wrapsFuture(ctx -> gameManager.loadGameState()))
                 )
                 .then(new StatsCommand(gameManager.getGameStateService()).create())
                 .permissionRoot("mctmanager")

--- a/src/main/java/org/braekpo1nt/mctmanager/commands/mct/admin/AdminCommand.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/commands/mct/admin/AdminCommand.java
@@ -1,32 +1,26 @@
 package org.braekpo1nt.mctmanager.commands.mct.admin;
 
 import com.mojang.brigadier.context.CommandContext;
-import com.mojang.brigadier.exceptions.CommandExceptionType;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
-import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import io.papermc.paper.command.brigadier.MessageComponentSerializer;
 import io.papermc.paper.command.brigadier.argument.resolvers.selector.PlayerSelectorArgumentResolver;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.TextDecoration;
-import org.braekpo1nt.mctmanager.Main;
 import org.braekpo1nt.mctmanager.commands.argumenttypes.OfflineAdminArgumentType;
 import org.braekpo1nt.mctmanager.commands.argumenttypes.OfflineAdminListResolver;
 import org.braekpo1nt.mctmanager.commands.manager.brigadier.BrigadierAdapters;
 import org.braekpo1nt.mctmanager.commands.manager.brigadier.BrigadierSubCommand;
 import org.braekpo1nt.mctmanager.commands.manager.brigadier.permissioned.Permissioned;
 import org.braekpo1nt.mctmanager.commands.manager.commandresult.CommandResult;
-import org.braekpo1nt.mctmanager.commands.manager.commandresult.CompositeCommandResult;
 import org.braekpo1nt.mctmanager.games.gamemanager.GameManager;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
-import java.util.logging.Level;
+import java.util.concurrent.CompletableFuture;
 
 public class AdminCommand implements BrigadierSubCommand {
     
@@ -47,12 +41,12 @@ public class AdminCommand implements BrigadierSubCommand {
         return Permissioned.literal("admin")
                 .then(Permissioned.literal("add")
                         .then(Permissioned.argument("player", gameManager.getPlayerArgumentType())
-                                .executes(BrigadierAdapters.wraps(this::executeAdd))
+                                .executes(BrigadierAdapters.wrapsFuture(this::executeAdd))
                         )
                 )
                 .then(Permissioned.literal("remove")
                         .then(Permissioned.argument("admin", new OfflineAdminArgumentType(gameManager))
-                                .executes(BrigadierAdapters.wraps(this::executeRemove))
+                                .executes(BrigadierAdapters.wrapsFuture(this::executeRemove))
                         )
                 )
                 .then(Permissioned.literal("test")
@@ -63,36 +57,41 @@ public class AdminCommand implements BrigadierSubCommand {
                 ;
     }
     
-    private @NotNull CommandResult executeRemove(CommandContext<CommandSourceStack> ctx) throws CommandSyntaxException {
+    private @NotNull CompletableFuture<CommandResult> executeRemove(CommandContext<CommandSourceStack> ctx) throws CommandSyntaxException {
         OfflineAdminListResolver adminResolver = ctx.getArgument("admin", OfflineAdminListResolver.class);
         Collection<OfflinePlayer> offlineAdmins = adminResolver.resolve(ctx.getSource());
-        List<CommandResult> results = new ArrayList<>(offlineAdmins.size());
+        CompletableFuture<CommandResult> chain = CompletableFuture.completedFuture(CommandResult.success());
         for (OfflinePlayer offlineAdmin : offlineAdmins) {
-            CommandResult result = gameManager.removeAdmin(offlineAdmin, offlineAdmin.getName() != null ? offlineAdmin.getName() : offlineAdmin.getUniqueId().toString());
-            results.add(result);
+            chain = CommandResult.appendAsync(
+                    chain,
+                    () -> gameManager.removeAdmin(offlineAdmin, offlineAdmin.getName() != null ? offlineAdmin.getName() : offlineAdmin.getUniqueId().toString()),
+                    gameManager.getMainThreadExecutor()
+            );
         }
-        return new CompositeCommandResult(results);
+        return chain;
     }
     
-    private @NotNull CommandResult executeAdd(CommandContext<CommandSourceStack> ctx) {
+    private @NotNull CompletableFuture<CommandResult> executeAdd(CommandContext<CommandSourceStack> ctx) {
         final PlayerSelectorArgumentResolver targetResolver = ctx.getArgument("player", PlayerSelectorArgumentResolver.class);
         try {
             final Player newAdmin = targetResolver.resolve(ctx.getSource()).getFirst();
             if (!newAdmin.isOnline()) {
                 return CommandResult.failure(Component.empty()
                         .append(newAdmin.displayName())
-                        .append(Component.text(" is not online")));
+                        .append(Component.text(" is not online"))
+                ).asFuture();
             }
             if (gameManager.isAdmin(newAdmin.getUniqueId())) {
                 return CommandResult.success(Component.empty()
                         .append(newAdmin.displayName())
-                        .append(Component.text(" is already an admin")));
+                        .append(Component.text(" is already an admin"))
+                ).asFuture();
             }
             return gameManager.addAdmin(newAdmin);
         } catch (CommandSyntaxException e) {
             return CommandResult.failure(Component.empty()
                     .append(Component.text("Could not find player"))
-            );
+            ).asFuture();
         }
         
     }

--- a/src/main/java/org/braekpo1nt/mctmanager/commands/mct/event/EventApplyPresetCommand.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/commands/mct/event/EventApplyPresetCommand.java
@@ -164,7 +164,7 @@ public class EventApplyPresetCommand implements BrigadierSubCommand {
                 return CommandResult.sqlException("apply preset to event", e);
             }
             return CommandResult.success(Component.text("Preset applied."));
-        });
+        }, plugin.getDatabaseExecutor());
     }
     
     /**

--- a/src/main/java/org/braekpo1nt/mctmanager/commands/mct/event/EventCommand.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/commands/mct/event/EventCommand.java
@@ -8,7 +8,6 @@ import io.papermc.paper.command.brigadier.CommandSourceStack;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
-import org.braekpo1nt.mctmanager.Main;
 import org.braekpo1nt.mctmanager.commands.argumenttypes.EventInfoArgumentType;
 import org.braekpo1nt.mctmanager.commands.argumenttypes.EventInfoResolver;
 import org.braekpo1nt.mctmanager.commands.manager.brigadier.BrigadierAdapters;
@@ -23,15 +22,14 @@ import org.jetbrains.annotations.NotNull;
 import java.sql.SQLException;
 import java.time.format.DateTimeParseException;
 import java.util.Date;
+import java.util.concurrent.CompletableFuture;
 
 public class EventCommand implements BrigadierSubCommand {
     
     private final @NotNull GameManager gameManager;
-    private final @NotNull Main plugin;
     
-    public EventCommand(@NotNull GameManager gameManager, @NotNull Main plugin) {
+    public EventCommand(@NotNull GameManager gameManager) {
         this.gameManager = gameManager;
-        this.plugin = plugin;
     }
     
     @Override
@@ -55,18 +53,18 @@ public class EventCommand implements BrigadierSubCommand {
         return Permissioned.literal("start")
                 .then(Permissioned.argument("eventId", new EventInfoArgumentType(gameManager.getEventService()))
                         .then(Permissioned.argument("numberOfGames", IntegerArgumentType.integer())
-                                .executes(BrigadierAdapters.wraps(ctx -> {
+                                .executes(BrigadierAdapters.wrapsFuture(ctx -> {
                                     try {
                                         EventInfoResolver eventInfoResolver = ctx.getArgument("eventId", EventInfoResolver.class);
                                         EventInfo eventInfo = eventInfoResolver.resolve();
                                         int maxGames = ctx.getArgument("numberOfGames", Integer.class);
                                         return gameManager.startEvent(eventInfo, maxGames, 1);
                                     } catch (SQLException e) {
-                                        return CommandResult.sqlException("get EventInfo", e);
+                                        return CommandResult.sqlException("get EventInfo", e).asFuture();
                                     }
                                 }))
                                 .then(Permissioned.argument("currentGameNumber", IntegerArgumentType.integer())
-                                        .executes(BrigadierAdapters.wraps(ctx -> {
+                                        .executes(BrigadierAdapters.wrapsFuture(ctx -> {
                                             try {
                                                 EventInfoResolver eventInfoResolver = ctx.getArgument("eventId", EventInfoResolver.class);
                                                 EventInfo eventInfo = eventInfoResolver.resolve();
@@ -74,7 +72,7 @@ public class EventCommand implements BrigadierSubCommand {
                                                 int currentGameNumber = ctx.getArgument("currentGameNumber", Integer.class);
                                                 return gameManager.startEvent(eventInfo, maxGames, currentGameNumber);
                                             } catch (SQLException e) {
-                                                return CommandResult.sqlException("get EventInfo", e);
+                                                return CommandResult.sqlException("get EventInfo", e).asFuture();
                                             }
                                         }))
                                 )
@@ -95,7 +93,7 @@ public class EventCommand implements BrigadierSubCommand {
                                 .color(NamedTextColor.YELLOW))
                 ))
                 .then(Permissioned.literal("confirm")
-                        .executes(BrigadierAdapters.wraps(ctx -> gameManager.stopEvent()))
+                        .executes(BrigadierAdapters.wrapsFuture(ctx -> gameManager.stopEvent()))
                 )
                 ;
     }
@@ -107,9 +105,9 @@ public class EventCommand implements BrigadierSubCommand {
                                 .suggests(TimeStringUtils::suggestDate)
                                 .then(Permissioned.argument("plainTextName", StringArgumentType.string())
                                         .then(Permissioned.argument("componentName", gameManager.getComponentArgumentType())
-                                                .executes(BrigadierAdapters.wraps(this::executeCreate))
+                                                .executes(BrigadierAdapters.wrapsFuture(this::executeCreate))
                                                 .then(Permissioned.argument("canonical", BoolArgumentType.bool())
-                                                        .executes(BrigadierAdapters.wraps(this::executeCreateCanonical))
+                                                        .executes(BrigadierAdapters.wrapsFuture(this::executeCreateCanonical))
                                                 )
                                         )
                                 )
@@ -117,16 +115,16 @@ public class EventCommand implements BrigadierSubCommand {
                 );
     }
     
-    private @NotNull CommandResult executeCreate(CommandContext<CommandSourceStack> ctx) {
+    private @NotNull CompletableFuture<CommandResult> executeCreate(CommandContext<CommandSourceStack> ctx) {
         return createEvent(ctx, true);
     }
     
-    private @NotNull CommandResult executeCreateCanonical(CommandContext<CommandSourceStack> ctx) {
+    private @NotNull CompletableFuture<CommandResult> executeCreateCanonical(CommandContext<CommandSourceStack> ctx) {
         boolean canonical = ctx.getArgument("canonical", Boolean.class);
         return createEvent(ctx, canonical);
     }
     
-    private CommandResult createEvent(CommandContext<CommandSourceStack> ctx, boolean canonical) {
+    private CompletableFuture<CommandResult> createEvent(CommandContext<CommandSourceStack> ctx, boolean canonical) {
         String eventId = ctx.getArgument("eventId", String.class);
         String eventDateString = ctx.getArgument("eventDate", String.class);
         Date eventDate;
@@ -136,7 +134,8 @@ public class EventCommand implements BrigadierSubCommand {
             return CommandResult.failure(Component.empty()
                     .append(Component.text("Could not parse date string "))
                     .append(Component.text(eventDateString)
-                            .decorate(TextDecoration.BOLD)));
+                            .decorate(TextDecoration.BOLD))
+            ).asFuture();
         }
         String plainTextName = ctx.getArgument("plainTextName", String.class);
         Component componentName = ctx.getArgument("componentName", Component.class);
@@ -162,7 +161,7 @@ public class EventCommand implements BrigadierSubCommand {
     private Permissioned<CommandSourceStack> buildMaxGames() {
         return Permissioned.literal("setMaxGames")
                 .then(Permissioned.argument("newCount", IntegerArgumentType.integer())
-                        .executes(BrigadierAdapters.wraps(ctx -> {
+                        .executes(BrigadierAdapters.wrapsFuture(ctx -> {
                             int newCount = ctx.getArgument("newCount", Integer.class);
                             return gameManager.modifyMaxGames(newCount);
                         }))

--- a/src/main/java/org/braekpo1nt/mctmanager/commands/mct/game/JoinSubCommand.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/commands/mct/game/JoinSubCommand.java
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 public class JoinSubCommand implements BrigadierSubCommand {
     
@@ -33,59 +34,61 @@ public class JoinSubCommand implements BrigadierSubCommand {
     @Override
     public @NotNull Permissioned<CommandSourceStack> create() {
         return Permissioned.literal("join")
-                .executes(BrigadierAdapters.wraps(this::executeJoin))
+                .executes(BrigadierAdapters.wrapsFuture(this::executeJoin))
                 .then(Commands.argument(GAME_ID_ARG, new GameIdArgumentType(gameManager, true))
-                        .executes(BrigadierAdapters.wraps(this::executeJoinGame))
+                        .executes(BrigadierAdapters.wrapsFuture(this::executeJoinGame))
                         .then(Commands.argument("configFile", new ConfigFileArgumentType(gameManager, true, GAME_ID_ARG))
-                                .executes(BrigadierAdapters.wraps(this::executeJoinGameConfig))
+                                .executes(BrigadierAdapters.wrapsFuture(this::executeJoinGameConfig))
                         )
                 )
                 ;
     }
     
-    private @NotNull CommandResult executeJoin(@NotNull CommandContext<CommandSourceStack> ctx) {
+    private @NotNull CompletableFuture<CommandResult> executeJoin(@NotNull CommandContext<CommandSourceStack> ctx) {
         List<GameInstanceId> activeGameIds = gameManager.getActiveGameIds();
         if (activeGameIds.size() == 1) {
             GameInstanceId id = activeGameIds.getFirst();
             if (!(ctx.getSource().getSender() instanceof Player player)) {
-                return CommandResult.failure("Only a player can use this command");
+                return CommandResult.failure("Only a player can use this command").asFuture();
             }
             return joinToGame(player, id.getGameType(), id.getConfigFile());
         } else if (activeGameIds.isEmpty()) {
             return CommandResult.failure(Component.empty()
-                    .append(Component.text("No games are active right now")));
+                    .append(Component.text("No games are active right now"))
+            ).asFuture();
         } else {
             return CommandResult.failure(Component.empty()
-                    .append(Component.text("Multiple games are active right now, please specify a game type")));
+                    .append(Component.text("Multiple games are active right now, please specify a game type"))
+            ).asFuture();
         }
     }
     
-    private @NotNull CommandResult executeJoinGame(@NotNull CommandContext<CommandSourceStack> ctx) {
+    private @NotNull CompletableFuture<CommandResult> executeJoinGame(@NotNull CommandContext<CommandSourceStack> ctx) {
         if (!(ctx.getSource().getSender() instanceof Player player)) {
-            return CommandResult.failure("Only a player can use this command");
+            return CommandResult.failure("Only a player can use this command").asFuture();
         }
         GameType gameType = ctx.getArgument(GAME_ID_ARG, GameType.class);
         return joinToGame(player, gameType, null);
     }
     
-    private @NotNull CommandResult executeJoinGameConfig(@NotNull CommandContext<CommandSourceStack> ctx) {
+    private @NotNull CompletableFuture<CommandResult> executeJoinGameConfig(@NotNull CommandContext<CommandSourceStack> ctx) {
         if (!(ctx.getSource().getSender() instanceof Player player)) {
-            return CommandResult.failure("Only a player can use this command");
+            return CommandResult.failure("Only a player can use this command").asFuture();
         }
         GameType gameType = ctx.getArgument(GAME_ID_ARG, GameType.class);
         String configFile = ctx.getArgument("configFile", String.class);
         return joinToGame(player, gameType, configFile);
     }
     
-    public @NotNull CommandResult joinToGame(@NotNull Player player, @NotNull GameType gameType, @Nullable String configFile) {
+    public @NotNull CompletableFuture<CommandResult> joinToGame(@NotNull Player player, @NotNull GameType gameType, @Nullable String configFile) {
         Participant participant = gameManager.getOnlineParticipant(player.getUniqueId());
         if (participant != null) {
             return gameManager.joinParticipantToGame(gameType, configFile, participant.getUniqueId());
         }
         
         if (gameManager.isAdmin(player.getUniqueId())) {
-            return gameManager.joinAdminToGame(gameType, configFile, player);
+            return gameManager.joinAdminToGame(gameType, configFile, player).asFuture();
         }
-        return CommandResult.failure("Only a participant or an admin can use this command");
+        return CommandResult.failure("Only a participant or an admin can use this command").asFuture();
     }
 }

--- a/src/main/java/org/braekpo1nt/mctmanager/commands/mct/game/StartSubCommand.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/commands/mct/game/StartSubCommand.java
@@ -2,6 +2,8 @@ package org.braekpo1nt.mctmanager.commands.mct.game;
 
 import com.mojang.brigadier.context.CommandContext;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
+import net.kyori.adventure.text.Component;
+import org.braekpo1nt.mctmanager.Main;
 import org.braekpo1nt.mctmanager.commands.argumenttypes.GreedyListArgumentType;
 import org.braekpo1nt.mctmanager.commands.manager.brigadier.permissioned.Permissioned;
 import org.braekpo1nt.mctmanager.commands.argumenttypes.ConfigFileArgumentType;
@@ -15,6 +17,8 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.logging.Level;
 import java.util.stream.Collectors;
 
 public class StartSubCommand implements BrigadierSubCommand {
@@ -31,33 +35,45 @@ public class StartSubCommand implements BrigadierSubCommand {
     public @NotNull Permissioned<CommandSourceStack> create() {
         return Permissioned.literal("start")
                 .then(Permissioned.argument(GAME_ID_ARG, new GameIdArgumentType(gameManager, false))
-                        .executes(BrigadierAdapters.wraps(this::executeStartDefault))
+                        .executes(BrigadierAdapters.wrapsFuture(this::executeStartDefault))
                         .then(Permissioned.argument("configFile", new ConfigFileArgumentType(gameManager, false, GAME_ID_ARG))
-                                .executes(BrigadierAdapters.wraps(this::executeStartConfig))
+                                .executes(BrigadierAdapters.wrapsFuture(this::executeStartConfig))
                                 .then(Permissioned.argument("teamIds", GreedyListArgumentType.teamIds(gameManager))
-                                        .executes(BrigadierAdapters.wraps(this::executeStartTeamIds))
+                                        .executes(BrigadierAdapters.wrapsFuture(this::executeStartTeamIds))
                                 )
                         )
                 )
                 ;
     }
     
-    private CommandResult executeStartDefault(CommandContext<CommandSourceStack> ctx) {
+    private CompletableFuture<CommandResult> executeStartDefault(CommandContext<CommandSourceStack> ctx) {
         GameType gameType = ctx.getArgument(GAME_ID_ARG, GameType.class);
-        return gameManager.startGame(gameType, "default.json");
+        return gameManager.startGame(gameType, "default.json")
+                .exceptionally(StartSubCommand::onGameStartFailure);
     }
     
-    private CommandResult executeStartConfig(CommandContext<CommandSourceStack> ctx) {
+    private CompletableFuture<CommandResult> executeStartConfig(CommandContext<CommandSourceStack> ctx) {
         GameType gameType = ctx.getArgument(GAME_ID_ARG, GameType.class);
         String configFile = ctx.getArgument("configFile", String.class);
-        return gameManager.startGame(gameType, configFile);
+        return gameManager.startGame(gameType, configFile)
+                .exceptionally(StartSubCommand::onGameStartFailure);
     }
     
-    private @NotNull CommandResult executeStartTeamIds(CommandContext<CommandSourceStack> ctx) {
+    private @NotNull CompletableFuture<CommandResult> executeStartTeamIds(CommandContext<CommandSourceStack> ctx) {
         GameType gameType = ctx.getArgument(GAME_ID_ARG, GameType.class);
         String configFile = ctx.getArgument("configFile", String.class);
         String[] teamIds = ctx.getArgument("teamIds", String[].class);
-        return gameManager.startGame(Arrays.stream(teamIds).collect(Collectors.toSet()), Collections.emptyList(), gameType, configFile);
+        return gameManager.startGame(Arrays.stream(teamIds).collect(Collectors.toSet()), Collections.emptyList(), gameType, configFile)
+                .exceptionally(StartSubCommand::onGameStartFailure);
+    }
+    
+    private static @NotNull CommandResult onGameStartFailure(Throwable e) {
+        Main.logger().log(Level.SEVERE, "Error thrown while starting game", e);
+        return CommandResult.failure(Component.empty()
+                .append(Component.text("Error occurred while starting game, see console for details."))
+                .append(Component.newline())
+                .append(Component.text(e.getMessage()))
+        );
     }
     
 }

--- a/src/main/java/org/braekpo1nt/mctmanager/commands/mct/game/StopSubCommand.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/commands/mct/game/StopSubCommand.java
@@ -12,6 +12,8 @@ import org.braekpo1nt.mctmanager.games.game.enums.GameType;
 import org.braekpo1nt.mctmanager.games.gamemanager.GameManager;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.concurrent.CompletableFuture;
+
 public class StopSubCommand implements BrigadierSubCommand {
     
     private final static String GAME_ID_ARG = "gameId";
@@ -25,26 +27,26 @@ public class StopSubCommand implements BrigadierSubCommand {
     @Override
     public @NotNull Permissioned<CommandSourceStack> create() {
         return Permissioned.literal("stop")
-                .executes(BrigadierAdapters.wraps(this::executeStopAll))
+                .executes(BrigadierAdapters.wrapsFuture(this::executeStopAll))
                 .then(Permissioned.argument(GAME_ID_ARG, new GameIdArgumentType(gameManager, true))
-                        .executes(BrigadierAdapters.wraps(this::executeStopGame))
+                        .executes(BrigadierAdapters.wrapsFuture(this::executeStopGame))
                         .then(Permissioned.argument("configFile", new ConfigFileArgumentType(gameManager, true, GAME_ID_ARG))
-                                .executes(BrigadierAdapters.wraps(this::executeStopGameConfig))
+                                .executes(BrigadierAdapters.wrapsFuture(this::executeStopGameConfig))
                         )
                 )
                 ;
     }
     
-    private @NotNull CommandResult executeStopAll(@NotNull CommandContext<CommandSourceStack> ctx) {
+    private @NotNull CompletableFuture<CommandResult> executeStopAll(@NotNull CommandContext<CommandSourceStack> ctx) {
         return gameManager.stopAllGames();
     }
     
-    private @NotNull CommandResult executeStopGame(@NotNull CommandContext<CommandSourceStack> ctx) {
+    private @NotNull CompletableFuture<CommandResult> executeStopGame(@NotNull CommandContext<CommandSourceStack> ctx) {
         GameType gameType = ctx.getArgument(GAME_ID_ARG, GameType.class);
         return gameManager.stopGame(gameType, null);
     }
     
-    private @NotNull CommandResult executeStopGameConfig(@NotNull CommandContext<CommandSourceStack> ctx) {
+    private @NotNull CompletableFuture<CommandResult> executeStopGameConfig(@NotNull CommandContext<CommandSourceStack> ctx) {
         GameType gameType = ctx.getArgument(GAME_ID_ARG, GameType.class);
         String configFile = ctx.getArgument("configFile", String.class);
         return gameManager.stopGame(gameType, configFile);

--- a/src/main/java/org/braekpo1nt/mctmanager/commands/mct/hub/HubCommand.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/commands/mct/hub/HubCommand.java
@@ -11,6 +11,8 @@ import org.braekpo1nt.mctmanager.participant.Participant;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.concurrent.CompletableFuture;
+
 public class HubCommand implements BrigadierSubCommand {
     
     private final @NotNull GameManager gameManager;
@@ -22,25 +24,25 @@ public class HubCommand implements BrigadierSubCommand {
     @Override
     public @NotNull Permissioned<CommandSourceStack> create() {
         return Permissioned.literal("hub")
-                .executes(BrigadierAdapters.wraps(this::executeTpToHub))
+                .executes(BrigadierAdapters.wrapsFuture(this::executeTpToHub))
                 .then(Permissioned.literal("menu")
                         .executes(BrigadierAdapters.wraps(this::executeMenu))
                 )
                 ;
     }
     
-    private @NotNull CommandResult executeTpToHub(@NotNull CommandContext<CommandSourceStack> ctx) {
+    private @NotNull CompletableFuture<CommandResult> executeTpToHub(@NotNull CommandContext<CommandSourceStack> ctx) {
         if (!(ctx.getSource().getSender() instanceof Player player)) {
-            return CommandResult.failure("This command can only be run by a player");
+            return CommandResult.failure("This command can only be run by a player").asFuture();
         }
         Participant participant = gameManager.getOnlineParticipant(player.getUniqueId());
         if (participant != null) {
             return gameManager.returnParticipantToHub(participant.getUniqueId());
         }
         if (gameManager.isAdmin(player.getUniqueId())) {
-            return gameManager.returnAdminToHub(player);
+            return gameManager.returnAdminToHub(player).asFuture();
         }
-        return CommandResult.failure("Only participants and admins can use this command");
+        return CommandResult.failure("Only participants and admins can use this command").asFuture();
     }
     
     private @NotNull CommandResult executeMenu(@NotNull CommandContext<CommandSourceStack> ctx) {

--- a/src/main/java/org/braekpo1nt/mctmanager/commands/mct/team/AddSubCommand.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/commands/mct/team/AddSubCommand.java
@@ -12,6 +12,8 @@ import org.braekpo1nt.mctmanager.games.gamemanager.GameManager;
 import org.braekpo1nt.mctmanager.games.utils.GameManagerUtils;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.concurrent.CompletableFuture;
+
 public class AddSubCommand implements BrigadierSubCommand {
     
     private final @NotNull GameManager gameManager;
@@ -27,14 +29,14 @@ public class AddSubCommand implements BrigadierSubCommand {
                         .then(Permissioned.argument("displayName", StringArgumentType.string())
                                 .then(Permissioned.argument("color", StringArgumentType.word())
                                         .suggests(CommandUtils::suggestColor)
-                                        .executes(BrigadierAdapters.wraps(this::executeAdd))
+                                        .executes(BrigadierAdapters.wrapsFuture(this::executeAdd))
                                 )
                         )
                 )
                 ;
     }
     
-    private @NotNull CommandResult executeAdd(CommandContext<CommandSourceStack> ctx) {
+    private @NotNull CompletableFuture<CommandResult> executeAdd(CommandContext<CommandSourceStack> ctx) {
         String teamId = ctx.getArgument("teamId", String.class);
         String displayName = ctx.getArgument("displayName", String.class);
         String colorString = ctx.getArgument("color", String.class);

--- a/src/main/java/org/braekpo1nt/mctmanager/commands/mct/team/JoinSubCommand.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/commands/mct/team/JoinSubCommand.java
@@ -45,19 +45,19 @@ public class JoinSubCommand implements BrigadierSubCommand {
     public @NotNull Permissioned<CommandSourceStack> create() {
         return Permissioned.literal("join")
                 .then(Permissioned.argument("teamId", new TeamArgumentType(gameManager))
-                        .executes(BrigadierAdapters.wraps(ctx -> {
+                        .executes(BrigadierAdapters.wrapsFuture(ctx -> {
                             Team team = ctx.getArgument("teamId", Team.class);
                             if (!(ctx.getSource().getSender() instanceof Player player)) {
-                                return CommandResult.failure("Must be a player to use the no-argument option");
+                                return CommandResult.failure("Must be a player to use the no-argument option").asFuture();
                             }
                             return gameManager.joinOnlineParticipant(player, team.getTeamId());
                         }))
                         .then(Permissioned.argument(IGN_ARGUMENT, StringArgumentType.word())
                                 .suggests((source, builder) -> suggestPlayerNames(builder))
-                                .executes(BrigadierAdapters.wraps(this::executeJoin))
+                                .executes(BrigadierAdapters.wrapsFuture(this::executeJoin))
                                 .then(Permissioned.argument("uuid", plugin.getUUIDArgumentType())
                                         .suggests((ctx, builder) -> JoinSubCommand.suggestPlayerUUID(ctx, builder, plugin))
-                                        .executes(BrigadierAdapters.wraps(this::executeJoinUUID))
+                                        .executes(BrigadierAdapters.wrapsFuture(this::executeJoinUUID))
                                 )
                         )
                 )
@@ -90,10 +90,10 @@ public class JoinSubCommand implements BrigadierSubCommand {
                     .filter(name -> name.toLowerCase().startsWith(builder.getRemainingLowerCase()))
                     .forEach(builder::suggest);
             return builder.build();
-        });
+        }, plugin.getDatabaseExecutor());
     }
     
-    private @NotNull CommandResult executeJoin(CommandContext<CommandSourceStack> ctx) throws CommandSyntaxException {
+    private @NotNull CompletableFuture<CommandResult> executeJoin(CommandContext<CommandSourceStack> ctx) throws CommandSyntaxException {
         Team team = ctx.getArgument("teamId", Team.class);
         String ign = ctx.getArgument(JoinSubCommand.IGN_ARGUMENT, String.class);
         // prioritize online players
@@ -107,12 +107,12 @@ public class JoinSubCommand implements BrigadierSubCommand {
                     .append(Component.text("Could not find uuid for player with ign "))
                     .append(Component.text(ign)
                             .decorate(TextDecoration.BOLD))
-            );
+            ).asFuture();
         }
         return gameManager.joinOfflineParticipant(uuid, ign, team.getTeamId());
     }
     
-    private @NotNull CommandResult executeJoinUUID(CommandContext<CommandSourceStack> ctx) throws CommandSyntaxException {
+    private @NotNull CompletableFuture<CommandResult> executeJoinUUID(CommandContext<CommandSourceStack> ctx) throws CommandSyntaxException {
         Team team = ctx.getArgument("teamId", Team.class);
         String ign = ctx.getArgument(JoinSubCommand.IGN_ARGUMENT, String.class);
         UUID uuid = ctx.getArgument("uuid", UUID.class);

--- a/src/main/java/org/braekpo1nt/mctmanager/commands/mct/team/LeaveSubCommand.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/commands/mct/team/LeaveSubCommand.java
@@ -13,6 +13,8 @@ import org.braekpo1nt.mctmanager.games.gamemanager.GameManager;
 import org.braekpo1nt.mctmanager.participant.OfflineParticipant;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.concurrent.CompletableFuture;
+
 public class LeaveSubCommand implements BrigadierSubCommand {
     
     private final @NotNull GameManager gameManager;
@@ -25,12 +27,12 @@ public class LeaveSubCommand implements BrigadierSubCommand {
     public @NotNull Permissioned<CommandSourceStack> create() {
         return Permissioned.literal("leave")
                 .then(Permissioned.argument("participant", new OfflineParticipantArgumentType(gameManager))
-                        .executes(BrigadierAdapters.wraps(this::executeLeave))
+                        .executes(BrigadierAdapters.wrapsFuture(this::executeLeave))
                 )
                 ;
     }
     
-    private @NotNull CommandResult executeLeave(CommandContext<CommandSourceStack> ctx) throws CommandSyntaxException {
+    private @NotNull CompletableFuture<CommandResult> executeLeave(CommandContext<CommandSourceStack> ctx) throws CommandSyntaxException {
         OfflineParticipant offlineParticipant = ctx.getArgument("participant", OfflineParticipantResolver.class)
                 .resolve();
         return gameManager.leaveParticipant(offlineParticipant);

--- a/src/main/java/org/braekpo1nt/mctmanager/commands/mct/team/RemoveSubCommand.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/commands/mct/team/RemoveSubCommand.java
@@ -11,6 +11,8 @@ import org.braekpo1nt.mctmanager.games.gamemanager.GameManager;
 import org.braekpo1nt.mctmanager.participant.Team;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.concurrent.CompletableFuture;
+
 public class RemoveSubCommand implements BrigadierSubCommand {
     
     
@@ -24,12 +26,12 @@ public class RemoveSubCommand implements BrigadierSubCommand {
     public @NotNull Permissioned<CommandSourceStack> create() {
         return Permissioned.literal("remove")
                 .then(Permissioned.argument("teamId", new TeamArgumentType(gameManager))
-                        .executes(BrigadierAdapters.wraps(this::executeRemove))
+                        .executes(BrigadierAdapters.wrapsFuture(this::executeRemove))
                 )
                 ;
     }
     
-    private @NotNull CommandResult executeRemove(CommandContext<CommandSourceStack> ctx) {
+    private @NotNull CompletableFuture<CommandResult> executeRemove(CommandContext<CommandSourceStack> ctx) {
         Team teamToRemove = ctx.getArgument("teamId", Team.class);
         return gameManager.removeTeam(teamToRemove.getTeamId());
     }

--- a/src/main/java/org/braekpo1nt/mctmanager/commands/mct/team/preset/PresetApplySubCommand.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/commands/mct/team/preset/PresetApplySubCommand.java
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.NotNull;
 import java.io.File;
 import java.util.Arrays;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 public class PresetApplySubCommand implements BrigadierSubCommand {
@@ -36,7 +37,7 @@ public class PresetApplySubCommand implements BrigadierSubCommand {
     @Override
     public @NotNull Permissioned<CommandSourceStack> create() {
         return Permissioned.literal("apply")
-                .executes(BrigadierAdapters.wraps(this::executeApplyNoOpts))
+                .executes(BrigadierAdapters.wrapsFuture(this::executeApplyNoOpts))
                 .then(Permissioned.argument("options", GreedyListArgumentType.of(
                                 Set.of(
                                         "override",
@@ -45,12 +46,12 @@ public class PresetApplySubCommand implements BrigadierSubCommand {
                                         "unWhitelist",
                                         "kickUnWhitelisted"
                                 )))
-                        .executes(BrigadierAdapters.wraps(this::executeApply))
+                        .executes(BrigadierAdapters.wrapsFuture(this::executeApply))
                 )
                 ;
     }
     
-    private @NotNull CommandResult executeApplyNoOpts(CommandContext<CommandSourceStack> ctx) throws CommandSyntaxException {
+    private @NotNull CompletableFuture<CommandResult> executeApplyNoOpts(CommandContext<CommandSourceStack> ctx) throws CommandSyntaxException {
         FileResolver resolver = ctx.getArgument(PresetCommand.PRESET_FILE_ARG, FileResolver.class);
         File presetFile = resolver.resolve();
         return GameManagerUtils.applyPreset(
@@ -63,7 +64,7 @@ public class PresetApplySubCommand implements BrigadierSubCommand {
         );
     }
     
-    private @NotNull CommandResult executeApply(CommandContext<CommandSourceStack> ctx) throws CommandSyntaxException {
+    private @NotNull CompletableFuture<CommandResult> executeApply(CommandContext<CommandSourceStack> ctx) throws CommandSyntaxException {
         String[] optionsArray = ctx.getArgument("options", String[].class);
         Set<String> options = Arrays.stream(optionsArray)
                 .collect(Collectors.toSet());

--- a/src/main/java/org/braekpo1nt/mctmanager/commands/mct/team/score/ScoreAddCommand.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/commands/mct/team/score/ScoreAddCommand.java
@@ -17,6 +17,8 @@ import org.braekpo1nt.mctmanager.participant.OfflineParticipant;
 import org.braekpo1nt.mctmanager.participant.Team;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.concurrent.CompletableFuture;
+
 public class ScoreAddCommand implements BrigadierSubCommand {
     
     private final @NotNull GameManager gameManager;
@@ -33,21 +35,21 @@ public class ScoreAddCommand implements BrigadierSubCommand {
                 .then(Permissioned.literal("participant")
                         .then(Permissioned.argument("participantName", new OfflineParticipantArgumentType(gameManager))
                                 .then(Permissioned.argument("score", IntegerArgumentType.integer())
-                                        .executes(BrigadierAdapters.wraps(this::executeAddParticipant))
+                                        .executes(BrigadierAdapters.wrapsFuture(this::executeAddParticipant))
                                 )
                         )
                 )
                 .then(Permissioned.literal("team")
                         .then(Permissioned.argument("teamId", new TeamArgumentType(gameManager))
                                 .then(Permissioned.argument("score", IntegerArgumentType.integer())
-                                        .executes(BrigadierAdapters.wraps(this::executeAddTeam))
+                                        .executes(BrigadierAdapters.wrapsFuture(this::executeAddTeam))
                                 )
                         )
                 )
                 ;
     }
     
-    private @NotNull CommandResult executeAddParticipant(CommandContext<CommandSourceStack> ctx) throws CommandSyntaxException {
+    private @NotNull CompletableFuture<CommandResult> executeAddParticipant(CommandContext<CommandSourceStack> ctx) throws CommandSyntaxException {
         OfflineParticipant offlineParticipant = ctx.getArgument("participantName", OfflineParticipantResolver.class)
                 .resolve();
         int score = ctx.getArgument("score", Integer.class);
@@ -58,14 +60,15 @@ public class ScoreAddCommand implements BrigadierSubCommand {
         if (currentScore + score < 0) {
             score = -currentScore;
         }
-        int newScore = gameManager.addScore(offlineParticipant, score, "add score to participant command");
-        return CommandResult.success(Component.empty()
-                .append(offlineParticipant.displayName())
-                .append(Component.text(" score is now "))
-                .append(Component.text(newScore)));
+        return gameManager.addScore(offlineParticipant, score, "add score to participant command")
+                .thenApply(newScore -> CommandResult.success(Component.empty()
+                        .append(offlineParticipant.displayName())
+                        .append(Component.text(" score is now "))
+                        .append(Component.text(newScore))))
+                ;
     }
     
-    private @NotNull CommandResult executeAddTeam(CommandContext<CommandSourceStack> ctx) {
+    private @NotNull CompletableFuture<CommandResult> executeAddTeam(CommandContext<CommandSourceStack> ctx) {
         Team team = ctx.getArgument("teamId", Team.class);
         int score = ctx.getArgument("score", Integer.class);
         int currentScore = team.getScore();
@@ -75,10 +78,11 @@ public class ScoreAddCommand implements BrigadierSubCommand {
         if (currentScore + score < 0) {
             score = -currentScore;
         }
-        int newScore = gameManager.addScore(team, score, "add score to team command");
-        return CommandResult.success(Component.empty()
-                .append(team.getFormattedDisplayName())
-                .append(Component.text(" score is now "))
-                .append(Component.text(newScore)));
+        return gameManager.addScore(team, score, "add score to team command")
+                .thenApply(newScore -> CommandResult.success(Component.empty()
+                        .append(team.getFormattedDisplayName())
+                        .append(Component.text(" score is now "))
+                        .append(Component.text(newScore))))
+                ;
     }
 }

--- a/src/main/java/org/braekpo1nt/mctmanager/commands/mct/team/score/ScoreSetCommand.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/commands/mct/team/score/ScoreSetCommand.java
@@ -17,6 +17,8 @@ import org.braekpo1nt.mctmanager.participant.OfflineParticipant;
 import org.braekpo1nt.mctmanager.participant.Team;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.concurrent.CompletableFuture;
+
 public class ScoreSetCommand implements BrigadierSubCommand {
     
     private final @NotNull GameManager gameManager;
@@ -31,61 +33,63 @@ public class ScoreSetCommand implements BrigadierSubCommand {
                 .then(Permissioned.literal("participant")
                         .then(Permissioned.argument("participantName", new OfflineParticipantArgumentType(gameManager))
                                 .then(Permissioned.argument("score", IntegerArgumentType.integer(0))
-                                        .executes(BrigadierAdapters.wraps(this::executeSetParticipant))
+                                        .executes(BrigadierAdapters.wrapsFuture(this::executeSetParticipant))
                                 )
                         )
                 )
                 .then(Permissioned.literal("team")
                         .then(Permissioned.argument("teamId", new TeamArgumentType(gameManager))
                                 .then(Permissioned.argument("score", IntegerArgumentType.integer(0))
-                                        .executes(BrigadierAdapters.wraps(this::executeSetTeam))
+                                        .executes(BrigadierAdapters.wrapsFuture(this::executeSetTeam))
                                 )
                         )
                 )
                 .then(Permissioned.literal("all")
                         .then(Permissioned.argument("score", IntegerArgumentType.integer(0))
-                                .executes(BrigadierAdapters.wraps(this::executeSetAll))
+                                .executes(BrigadierAdapters.wrapsFuture(this::executeSetAll))
                         )
                 )
                 ;
     }
     
-    private @NotNull CommandResult executeSetParticipant(CommandContext<CommandSourceStack> ctx) throws CommandSyntaxException {
+    private @NotNull CompletableFuture<CommandResult> executeSetParticipant(CommandContext<CommandSourceStack> ctx) throws CommandSyntaxException {
         OfflineParticipant offlineParticipant = ctx.getArgument("participantName", OfflineParticipantResolver.class)
                 .resolve();
         int score = ctx.getArgument("score", Integer.class);
         if (score < 0) {
-            return CommandResult.failure(Component.text("Score must be at least 0"));
+            return CommandResult.failure(Component.text("Score must be at least 0")).asFuture();
         }
-        int newScore = gameManager.setScore(offlineParticipant, score, "set score of participant command");
-        return CommandResult.success(Component.empty()
-                .append(offlineParticipant.displayName())
-                .append(Component.text(" score is now "))
-                .append(Component.text(newScore)));
+        return gameManager.setScore(offlineParticipant, score, "set score of participant command")
+                .thenApply(newScore -> CommandResult.success(Component.empty()
+                        .append(offlineParticipant.displayName())
+                        .append(Component.text(" score is now "))
+                        .append(Component.text(newScore))))
+                ;
     }
     
-    private @NotNull CommandResult executeSetTeam(CommandContext<CommandSourceStack> ctx) {
+    private @NotNull CompletableFuture<CommandResult> executeSetTeam(CommandContext<CommandSourceStack> ctx) {
         Team team = ctx.getArgument("teamId", Team.class);
         int score = ctx.getArgument("score", Integer.class);
         if (score < 0) {
-            return CommandResult.failure(Component.text("Score must be at least 0"));
+            return CommandResult.failure(Component.text("Score must be at least 0")).asFuture();
         }
-        int newScore = gameManager.setScore(team, score, "set score of team command");
-        return CommandResult.success(Component.empty()
-                .append(team.getFormattedDisplayName())
-                .append(Component.text(" score is now "))
-                .append(Component.text(newScore)));
+        return gameManager.setScore(team, score, "set score of team command")
+                .thenApply(newScore -> CommandResult.success(Component.empty()
+                        .append(team.getFormattedDisplayName())
+                        .append(Component.text(" score is now "))
+                        .append(Component.text(newScore))))
+                ;
     }
     
-    private @NotNull CommandResult executeSetAll(CommandContext<CommandSourceStack> ctx) {
+    private @NotNull CompletableFuture<CommandResult> executeSetAll(CommandContext<CommandSourceStack> ctx) {
         int score = ctx.getArgument("score", Integer.class);
         if (score < 0) {
-            return CommandResult.failure(Component.text("Score must be at least 0"));
+            return CommandResult.failure(Component.text("Score must be at least 0")).asFuture();
         }
-        gameManager.setScoreAll(score, "set score all command");
+        return gameManager.setScoreAll(score, "set score all command")
+                .thenApply(v -> CommandResult.success(Component.empty()
+                        .append(Component.text("All team and participant scores have been set to "))
+                        .append(Component.text(score))));
         
-        return CommandResult.success(Component.empty()
-                .append(Component.text("All team and participant scores have been set to "))
-                .append(Component.text(score)));
     }
 }

--- a/src/main/java/org/braekpo1nt/mctmanager/commands/mctdebug/MCTDebugCommand.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/commands/mctdebug/MCTDebugCommand.java
@@ -29,7 +29,9 @@ import org.braekpo1nt.mctmanager.games.gamestate.preset.PresetDTO;
 import org.braekpo1nt.mctmanager.games.gamestate.preset.legacy.LegacyPresetController;
 import org.braekpo1nt.mctmanager.games.gamestate.preset.legacy.LegacyPresetDTO;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
+import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
@@ -37,6 +39,10 @@ import java.sql.SQLException;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.logging.Level;
 
 /**
@@ -82,14 +88,14 @@ public class MCTDebugCommand implements BrigadierCommand, Listener {
                 .then(Permissioned.literal("rebuild")
                         .then(Permissioned.literal("event")
                                 .then(Commands.argument("eventId", new EventInfoArgumentType(gameManager.getEventService()))
-                                        .executes(BrigadierAdapters.wraps(this::executeRebuildEvent))
+                                        .executes(BrigadierAdapters.wrapsFuture(this::executeRebuildEvent))
                                 )
                         )
                         .then(Permissioned.literal("maintenance")
-                                .executes(BrigadierAdapters.wraps(this::executeRebuildMaintenance))
+                                .executes(BrigadierAdapters.wrapsFuture(this::executeRebuildMaintenance))
                         )
                         .then(Permissioned.literal("practice")
-                                .executes(BrigadierAdapters.wraps(this::executeRebuildPractice))
+                                .executes(BrigadierAdapters.wrapsFuture(this::executeRebuildPractice))
                         )
                 )
                 .then(Permissioned.literal("totals")
@@ -180,42 +186,60 @@ public class MCTDebugCommand implements BrigadierCommand, Listener {
     }
     
     private @NotNull CompletableFuture<CommandResult> executeAsyncTest(CommandContext<CommandSourceStack> ctx) throws CommandSyntaxException {
+        ExecutorService databaseExecutor = Executors.newFixedThreadPool(
+                4,
+                r -> {
+                    Thread thread = new Thread(r);
+                    thread.setName("mctmanager-db-worker");
+                    thread.setDaemon(true);
+                    return thread;
+                });
+        Executor mainThreadExecutor = plugin.getServer().getScheduler().getMainThreadExecutor(plugin);
+        CommandSender sender = ctx.getSource().getSender();
+        if (!(sender instanceof Player player)) {
+            return CommandResult.failure("Failed").asFuture();
+        }
         return CompletableFuture.supplyAsync(() -> {
-            ctx.getSource().getSender().sendMessage(Component.text("Async message"));
-            return CommandResult.success(Component.text("Sync message"));
-        });
+                    try {
+                        return gameManager.getGameStateService().getPlayerIGNs().size();
+                    } catch (SQLException e) {
+                        throw new CompletionException(e);
+                    }
+                }, databaseExecutor)
+                .thenComposeAsync(size ->
+                        CompletableFuture.supplyAsync(() -> {
+                            player.teleport(player.getLocation().clone().add(new Vector(0, 10, 0)));
+                            sender.sendMessage(Component.text("size is ")
+                                    .append(Component.text(size)));
+                            return CommandResult.success(Component.text("message 2"));
+                        }, mainThreadExecutor)
+                )
+                ;
     }
     
-    private @NotNull CommandResult executeRebuildEvent(CommandContext<CommandSourceStack> ctx) throws CommandSyntaxException {
+    private @NotNull CompletableFuture<CommandResult> executeRebuildEvent(CommandContext<CommandSourceStack> ctx) throws CommandSyntaxException {
         EventInfoResolver resolver = ctx.getArgument("eventId", EventInfoResolver.class);
         try {
             EventInfo eventInfo = resolver.resolve();
-            gameManager.getGameStateService().rebuildEventMode(eventInfo.getEventId());
-            return CommandResult.success(Component.text("Loaded event mode"));
+            return gameManager.getGameStateService().rebuildEventMode(eventInfo.getEventId())
+                    .thenApply(v -> CommandResult.success(Component.text("Rebuilt event mode")))
+                    .exceptionally(e -> CommandResult.throwable("rebuild event mode", e));
         } catch (SQLException e) {
             Main.logger().log(Level.SEVERE, "An error occurred trying to rebuild practice mode", e);
-            return CommandResult.failure("An error occurred, see the console for more");
+            return CommandResult.failure("An error occurred, see the console for more").asFuture();
         }
     }
     
-    private @NotNull CommandResult executeRebuildMaintenance(CommandContext<CommandSourceStack> ctx) {
-        try {
-            gameManager.getGameStateService().rebuildMaintenanceMode();
-            return CommandResult.success(Component.text("Loaded maintenance mode"));
-        } catch (SQLException e) {
-            Main.logger().log(Level.SEVERE, "An error occurred trying to rebuild practice mode", e);
-            return CommandResult.failure("An error occurred, see the console for more");
-        }
+    private @NotNull CompletableFuture<CommandResult> executeRebuildMaintenance(CommandContext<CommandSourceStack> ctx) {
+        return gameManager.getGameStateService().rebuildMaintenanceMode()
+                .thenApply(v -> CommandResult.success(Component.text("Rebuilt maintenance mode")))
+                .exceptionally(e -> CommandResult.throwable("rebuild maintenance mode", e));
     }
     
-    private @NotNull CommandResult executeRebuildPractice(CommandContext<CommandSourceStack> ctx) {
-        try {
-            gameManager.getGameStateService().rebuildPracticeMode();
-            return CommandResult.success(Component.text("Loaded practice mode"));
-        } catch (SQLException e) {
-            Main.logger().log(Level.SEVERE, "An error occurred trying to rebuild practice mode", e);
-            return CommandResult.failure("An error occurred, see the console for more");
-        }
+    private @NotNull CompletableFuture<CommandResult> executeRebuildPractice(CommandContext<CommandSourceStack> ctx) {
+        return gameManager.getGameStateService().rebuildPracticeMode()
+                .thenApply(v -> CommandResult.success(Component.text("Rebuilt practice mode")))
+                .exceptionally(e -> CommandResult.throwable("rebuild practice mode", e));
     }
     
     private @NotNull CommandResult executeDebug(CommandContext<CommandSourceStack> ctx) {

--- a/src/main/java/org/braekpo1nt/mctmanager/database/Database.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/database/Database.java
@@ -30,6 +30,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.sql.SQLException;
 import java.sql.SQLIntegrityConstraintViolationException;
+import java.util.concurrent.Executor;
 
 @Getter
 public class Database {
@@ -57,7 +58,9 @@ public class Database {
     private final @NotNull Dao<PlayerMetadata, String> playerMetadataDao;
     private final @NotNull ConnectionSource connectionSource;
     
-    private Database(@NotNull ConnectionSource connectionSource) throws SQLException {
+    private final @NotNull Executor databaseExecutor;
+    
+    private Database(@NotNull ConnectionSource connectionSource, @NotNull Executor databaseExecutor) throws SQLException {
         // flyway creates the tables, no need for TableUtils:
 //        TableUtils.createTableIfNotExists(connectionSource, EventInfo.class);
         this.connectionSource = connectionSource;
@@ -84,6 +87,8 @@ public class Database {
         this.gameSessionDao = DaoManager.createDao(connectionSource, GameSession.class);
         this.scoreEventsDao = DaoManager.createDao(connectionSource, ScoreEventEntity.class);
         this.playerMetadataDao = DaoManager.createDao(connectionSource, PlayerMetadata.class);
+        
+        this.databaseExecutor = databaseExecutor;
     }
     
     public Database(
@@ -91,8 +96,9 @@ public class Database {
             String port,
             String user,
             String password,
-            String databaseName) throws SQLException {
-        this(getConnectionSource(host, port, user, password, databaseName));
+            String databaseName,
+            @NotNull Executor databaseExecutor) throws SQLException {
+        this(getConnectionSource(host, port, user, password, databaseName), databaseExecutor);
     }
     
     /**
@@ -113,12 +119,8 @@ public class Database {
         return jdbcPooledConnectionSource;
     }
     
-    public Database(String sqlitePath) throws SQLException {
-        this(new JdbcConnectionSource("jdbc:sqlite:" + sqlitePath + "?foreign_keys=on"));
-    }
-    
-    public static Database createInMemorySQLite() throws SQLException {
-        return new Database(new JdbcConnectionSource("jdbc:sqlite::memory:"));
+    public Database(String sqlitePath, @NotNull Executor databaseExecutor) throws SQLException {
+        this(new JdbcConnectionSource("jdbc:sqlite:" + sqlitePath + "?foreign_keys=on"), databaseExecutor);
     }
     
     public void close() throws Exception {

--- a/src/main/java/org/braekpo1nt/mctmanager/database/service/GameStateService.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/database/service/GameStateService.java
@@ -37,10 +37,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
 
 @SuppressWarnings("UnusedReturnValue")
 public class GameStateService {
     private final @NotNull String mode;
+    private final @NotNull Executor databaseExecutor;
     private final @NotNull Dao<AllPlayersEntity, String> allPlayersDao;
     private final @NotNull Dao<PlayerMetadata, String> playerMetadataDao;
     private final @NotNull Dao<SystemState, Integer> systemStateDao;
@@ -64,6 +68,7 @@ public class GameStateService {
     
     public GameStateService(@NotNull String mode, @NotNull Database database) {
         this.mode = mode;
+        this.databaseExecutor = database.getDatabaseExecutor();
         this.allPlayersDao = database.getAllPlayersDao();
         this.playerMetadataDao = database.getPlayerMetadataDao();
         this.systemStateDao = database.getSystemStateDao();
@@ -881,21 +886,77 @@ public class GameStateService {
     }
     
     /**
-     * @return a map from UUID to Admin Names
+     * @return a map from UUID to maintenance Admin Names
      * @throws SQLException if there's a SQL error
      */
-    public @NotNull Map<UUID, String> getAdminNames() throws SQLException {
+    public @NotNull Map<UUID, String> getMaintenanceAdminNames() throws SQLException {
         String sql = """
                 SELECT
                     ad.uuid,
                     ap.ign
-                FROM admins ad
+                FROM maintenance_admins ad
                 LEFT JOIN all_players ap
                     ON ad.uuid = ap.uuid;
                 """;
         Map<UUID, String> result = new HashMap<>();
         try (GenericRawResults<String[]> raw =
                      activeAdminDao.queryRaw(sql)) {
+            for (String[] row : raw.getResults()) {
+                UUID uuid = UUID.fromString(row[0]);
+                String ign = row[1];
+                result.put(uuid, ign);
+            }
+        } catch (Exception e) {
+            throw new SQLException("Exception thrown while getting admin names", e);
+        }
+        return result;
+    }
+    
+    /**
+     * @return a map from UUID to practice Admin Names
+     * @throws SQLException if there's a SQL error
+     */
+    public @NotNull Map<UUID, String> getPracticeAdminNames() throws SQLException {
+        String sql = """
+                SELECT
+                    ad.uuid,
+                    ap.ign
+                FROM practice_admins ad
+                LEFT JOIN all_players ap
+                    ON ad.uuid = ap.uuid;
+                """;
+        Map<UUID, String> result = new HashMap<>();
+        try (GenericRawResults<String[]> raw =
+                     activeAdminDao.queryRaw(sql)) {
+            for (String[] row : raw.getResults()) {
+                UUID uuid = UUID.fromString(row[0]);
+                String ign = row[1];
+                result.put(uuid, ign);
+            }
+        } catch (Exception e) {
+            throw new SQLException("Exception thrown while getting admin names", e);
+        }
+        return result;
+    }
+    
+    /**
+     * @param eventId the eventId to get the admin names for
+     * @return a map from UUID to event Admin Names for the given eventId
+     * @throws SQLException if there's a SQL error
+     */
+    public @NotNull Map<UUID, String> getEventAdminNames(@NotNull String eventId) throws SQLException {
+        String sql = """
+                SELECT
+                    ad.uuid,
+                    ap.ign
+                FROM event_admins ad
+                LEFT JOIN all_players ap
+                    ON ad.uuid = ap.uuid
+                WHERE ad.event_id = ?;
+                """;
+        Map<UUID, String> result = new HashMap<>();
+        try (GenericRawResults<String[]> raw =
+                     activeAdminDao.queryRaw(sql, eventId)) {
             for (String[] row : raw.getResults()) {
                 UUID uuid = UUID.fromString(row[0]);
                 String ign = row[1];
@@ -1065,251 +1126,278 @@ SELECT
     WHERE se.participant_uuid IS NOT NULL;
      */
     
-    public void rebuildMaintenanceMode() throws SQLException {
-        TransactionManager.callInTransaction(activeTeamsDao.getConnectionSource(), () -> {
-            // clear
-            activeTeamsDao.executeRaw("DELETE FROM in_game_participants");
-            activeTeamsDao.executeRaw("DELETE FROM in_game_teams");
-            activeTeamsDao.executeRaw("DELETE FROM active_participants");
-            activeTeamsDao.executeRaw("DELETE FROM active_teams");
-            activeTeamsDao.executeRaw("DELETE FROM active_admins");
-            
-            // rebuild teams
-            activeTeamsDao.executeRaw("""
-                    INSERT INTO active_teams (team_id, display_name, color, score)
-                    SELECT
-                        mt.team_id,
-                        mt.display_name,
-                        mt.color,
-                        COALESCE(se.total, 0) AS total
-                    FROM maintenance_teams mt
-                    LEFT JOIN (
-                        SELECT
-                            se.team_id,
-                            SUM(
-                                CASE
-                                    WHEN se.session_id IS NULL THEN se.points_base
-                                    WHEN gs.session_undone = FALSE THEN FLOOR(se.points_base * gs.multiplier)
-                                    ELSE 0
-                                END
-                            ) AS total
-                        FROM score_events se
-                        LEFT JOIN game_sessions gs
-                            ON gs.id = se.session_id
-                        WHERE se.mode = 'MAINTENANCE'
-                        GROUP BY se.team_id
-                    ) se
-                        ON se.team_id = mt.team_id
-                    """);
-            
-            // rebuild participants
-            activeTeamsDao.executeRaw("""
-                    INSERT INTO active_participants (participant_uuid, team_id, ign, score)
-                    SELECT
-                        mp.participant_uuid,
-                        mp.team_id,
-                        ap.ign,
-                        COALESCE(se.total, 0) AS total
-                    FROM maintenance_participants mp
-                    JOIN all_players ap
-                      ON ap.uuid = mp.participant_uuid
-                    LEFT JOIN (
-                        SELECT se.participant_uuid,
-                               SUM(se.points_base) AS total
-                        FROM score_events se
-                        LEFT JOIN game_sessions gs
-                          ON gs.id = se.session_id
-                        WHERE se.mode = 'MAINTENANCE'
-                          AND se.participant_uuid IS NOT NULL
-                          AND (
-                                se.session_id IS NULL
-                             OR gs.session_undone = FALSE
-                          )
-                        GROUP BY se.participant_uuid
-                    ) se
-                      ON se.participant_uuid = mp.participant_uuid
-                    """);
-            
-            // rebuild admins
-            activeTeamsDao.executeRaw("""
-                        INSERT INTO active_admins (uuid)
-                        SELECT
-                        	ma.uuid
-                        FROM maintenance_admins ma
-                    """);
-            
-            incrementActiveVersion();
-            return null;
-        });
+    public CompletableFuture<Void> rebuildMaintenanceMode() {
+        return CompletableFuture.runAsync(() -> {
+                    try {
+                        TransactionManager.callInTransaction(activeTeamsDao.getConnectionSource(), () -> {
+                            // clear
+                            activeTeamsDao.executeRaw("DELETE FROM in_game_participants");
+                            activeTeamsDao.executeRaw("DELETE FROM in_game_teams");
+                            activeTeamsDao.executeRaw("DELETE FROM active_participants");
+                            activeTeamsDao.executeRaw("DELETE FROM active_teams");
+                            activeTeamsDao.executeRaw("DELETE FROM active_admins");
+                            
+                            // rebuild teams
+                            activeTeamsDao.executeRaw("""
+                                    INSERT INTO active_teams (team_id, display_name, color, score)
+                                    SELECT
+                                        mt.team_id,
+                                        mt.display_name,
+                                        mt.color,
+                                        COALESCE(se.total, 0) AS total
+                                    FROM maintenance_teams mt
+                                    LEFT JOIN (
+                                        SELECT
+                                            se.team_id,
+                                            SUM(
+                                                CASE
+                                                    WHEN se.session_id IS NULL THEN se.points_base
+                                                    WHEN gs.session_undone = FALSE THEN FLOOR(se.points_base * gs.multiplier)
+                                                    ELSE 0
+                                                END
+                                            ) AS total
+                                        FROM score_events se
+                                        LEFT JOIN game_sessions gs
+                                            ON gs.id = se.session_id
+                                        WHERE se.mode = 'MAINTENANCE'
+                                        GROUP BY se.team_id
+                                    ) se
+                                        ON se.team_id = mt.team_id
+                                    """);
+                            
+                            // rebuild participants
+                            activeTeamsDao.executeRaw("""
+                                    INSERT INTO active_participants (participant_uuid, team_id, ign, score)
+                                    SELECT
+                                        mp.participant_uuid,
+                                        mp.team_id,
+                                        ap.ign,
+                                        COALESCE(se.total, 0) AS total
+                                    FROM maintenance_participants mp
+                                    JOIN all_players ap
+                                      ON ap.uuid = mp.participant_uuid
+                                    LEFT JOIN (
+                                        SELECT se.participant_uuid,
+                                               SUM(se.points_base) AS total
+                                        FROM score_events se
+                                        LEFT JOIN game_sessions gs
+                                          ON gs.id = se.session_id
+                                        WHERE se.mode = 'MAINTENANCE'
+                                          AND se.participant_uuid IS NOT NULL
+                                          AND (
+                                                se.session_id IS NULL
+                                             OR gs.session_undone = FALSE
+                                          )
+                                        GROUP BY se.participant_uuid
+                                    ) se
+                                      ON se.participant_uuid = mp.participant_uuid
+                                    """);
+                            
+                            // rebuild admins
+                            activeTeamsDao.executeRaw("""
+                                        INSERT INTO active_admins (uuid)
+                                        SELECT
+                                        	ma.uuid
+                                        FROM maintenance_admins ma
+                                    """);
+                            
+                            incrementActiveVersion();
+                            return null;
+                        });
+                    } catch (SQLException e) {
+                        throw new CompletionException(e);
+                    }
+                }, databaseExecutor)
+                .exceptionally(e -> {
+                    throw new CompletionException("A database error occurred rebuilding maintenance mode", e);
+                });
     }
     
-    public void rebuildPracticeMode() throws SQLException {
-        TransactionManager.callInTransaction(activeTeamsDao.getConnectionSource(), () -> {
-            // clear
-            activeTeamsDao.executeRaw("DELETE FROM in_game_participants");
-            activeTeamsDao.executeRaw("DELETE FROM in_game_teams");
-            activeTeamsDao.executeRaw("DELETE FROM active_participants");
-            activeTeamsDao.executeRaw("DELETE FROM active_teams");
-            activeTeamsDao.executeRaw("DELETE FROM active_admins");
-            
-            // rebuild teams
-            activeTeamsDao.executeRaw("""
-                    INSERT INTO active_teams (team_id, display_name, color, score)
-                    SELECT
-                        pt.team_id,
-                        pt.display_name,
-                        pt.color,
-                        COALESCE(se.total, 0) AS total
-                    FROM practice_teams pt
-                    LEFT JOIN (
-                        SELECT
-                            se.team_id,
-                            SUM(
-                                CASE
-                                    WHEN se.session_id IS NULL THEN se.points_base
-                                    WHEN gs.session_undone = FALSE THEN FLOOR(se.points_base * gs.multiplier)
-                                    ELSE 0
-                                END
-                            ) AS total
-                        FROM score_events se
-                        LEFT JOIN game_sessions gs
-                            ON gs.id = se.session_id
-                        WHERE se.mode = 'PRACTICE'
-                        GROUP BY se.team_id
-                    ) se
-                        ON se.team_id = pt.team_id
-                    """);
-            
-            // rebuild participants
-            activeTeamsDao.executeRaw("""
-                        INSERT INTO active_participants (participant_uuid, team_id, ign, score)
-                        SELECT
-                            pp.participant_uuid,
-                            pp.team_id,
-                            ap.ign,
-                            COALESCE(se.total, 0) AS total
-                        FROM practice_participants pp
-                        JOIN all_players ap
-                          ON ap.uuid = pp.participant_uuid
-                        LEFT JOIN (
-                            SELECT se.participant_uuid,
-                                   SUM(se.points_base) AS total
-                            FROM score_events se
-                            LEFT JOIN game_sessions gs
-                              ON gs.id = se.session_id
-                            WHERE se.mode = 'PRACTICE'
-                              AND se.participant_uuid IS NOT NULL
-                              AND (
-                                    se.session_id IS NULL
-                                 OR gs.session_undone = FALSE
-                              )
-                            GROUP BY se.participant_uuid
-                        ) se
-                          ON se.participant_uuid = pp.participant_uuid
-                    """);
-            
-            // rebuild admins
-            activeTeamsDao.executeRaw("""
-                        INSERT INTO active_admins (uuid)
-                        SELECT
-                        	pa.uuid
-                        FROM practice_admins pa
-                    """);
-            
-            incrementActiveVersion();
-            return null;
-        });
+    public CompletableFuture<Void> rebuildPracticeMode() {
+        return CompletableFuture.runAsync(() -> {
+                    try {
+                        TransactionManager.callInTransaction(activeTeamsDao.getConnectionSource(), () -> {
+                            // clear
+                            activeTeamsDao.executeRaw("DELETE FROM in_game_participants");
+                            activeTeamsDao.executeRaw("DELETE FROM in_game_teams");
+                            activeTeamsDao.executeRaw("DELETE FROM active_participants");
+                            activeTeamsDao.executeRaw("DELETE FROM active_teams");
+                            activeTeamsDao.executeRaw("DELETE FROM active_admins");
+                            
+                            // rebuild teams
+                            activeTeamsDao.executeRaw("""
+                                    INSERT INTO active_teams (team_id, display_name, color, score)
+                                    SELECT
+                                        pt.team_id,
+                                        pt.display_name,
+                                        pt.color,
+                                        COALESCE(se.total, 0) AS total
+                                    FROM practice_teams pt
+                                    LEFT JOIN (
+                                        SELECT
+                                            se.team_id,
+                                            SUM(
+                                                CASE
+                                                    WHEN se.session_id IS NULL THEN se.points_base
+                                                    WHEN gs.session_undone = FALSE THEN FLOOR(se.points_base * gs.multiplier)
+                                                    ELSE 0
+                                                END
+                                            ) AS total
+                                        FROM score_events se
+                                        LEFT JOIN game_sessions gs
+                                            ON gs.id = se.session_id
+                                        WHERE se.mode = 'PRACTICE'
+                                        GROUP BY se.team_id
+                                    ) se
+                                        ON se.team_id = pt.team_id
+                                    """);
+                            
+                            // rebuild participants
+                            activeTeamsDao.executeRaw("""
+                                        INSERT INTO active_participants (participant_uuid, team_id, ign, score)
+                                        SELECT
+                                            pp.participant_uuid,
+                                            pp.team_id,
+                                            ap.ign,
+                                            COALESCE(se.total, 0) AS total
+                                        FROM practice_participants pp
+                                        JOIN all_players ap
+                                          ON ap.uuid = pp.participant_uuid
+                                        LEFT JOIN (
+                                            SELECT se.participant_uuid,
+                                                   SUM(se.points_base) AS total
+                                            FROM score_events se
+                                            LEFT JOIN game_sessions gs
+                                              ON gs.id = se.session_id
+                                            WHERE se.mode = 'PRACTICE'
+                                              AND se.participant_uuid IS NOT NULL
+                                              AND (
+                                                    se.session_id IS NULL
+                                                 OR gs.session_undone = FALSE
+                                              )
+                                            GROUP BY se.participant_uuid
+                                        ) se
+                                          ON se.participant_uuid = pp.participant_uuid
+                                    """);
+                            
+                            // rebuild admins
+                            activeTeamsDao.executeRaw("""
+                                        INSERT INTO active_admins (uuid)
+                                        SELECT
+                                        	pa.uuid
+                                        FROM practice_admins pa
+                                    """);
+                            
+                            incrementActiveVersion();
+                            return null;
+                        });
+                    } catch (SQLException e) {
+                        throw new CompletionException(e);
+                    }
+                }, databaseExecutor)
+                .exceptionally(e -> {
+                    throw new CompletionException("A database error occurred rebuilding practice mode", e);
+                });
     }
     
-    public void rebuildEventMode(@NotNull String eventId) throws SQLException {
-        TransactionManager.callInTransaction(activeTeamsDao.getConnectionSource(), () -> {
-            // clear
-            activeTeamsDao.executeRaw("DELETE FROM in_game_participants");
-            activeTeamsDao.executeRaw("DELETE FROM in_game_teams");
-            activeTeamsDao.executeRaw("DELETE FROM active_participants");
-            activeTeamsDao.executeRaw("DELETE FROM active_teams");
-            activeTeamsDao.executeRaw("DELETE FROM active_admins");
-            
-            // rebuild teams
-            activeTeamsDao.executeRaw("""
-                            INSERT INTO active_teams (team_id, display_name, color, score)
-                            SELECT
-                                et.team_id,
-                                et.display_name,
-                                et.color,
-                                CAST(COALESCE(se.total, 0) AS SIGNED) AS total
-                            FROM event_teams et
-                            LEFT JOIN (
-                                SELECT
-                                    se.team_id,
-                                    SUM(
-                                        CASE
-                                            WHEN se.session_id IS NULL THEN se.points_base
-                                            WHEN gs.session_undone = FALSE THEN FLOOR(se.points_base * gs.multiplier)
-                                            ELSE 0
-                                        END
-                                    ) AS total
-                                FROM score_events se
-                                LEFT JOIN game_sessions gs
-                                    ON gs.id = se.session_id
-                                WHERE se.event_id = ?
-                                GROUP BY se.team_id
-                            ) se
-                                ON se.team_id = et.team_id
-                            WHERE et.event_id = ?
-                            """,
-                    eventId,
-                    eventId
-            );
-            
-            // rebuild participants
-            activeTeamsDao.executeRaw("""
-                            INSERT INTO active_participants (participant_uuid, team_id, ign, score)
-                            SELECT
-                                ep.participant_uuid,
-                                ep.team_id,
-                                ap.ign,
-                                CAST(COALESCE(se.total, 0) AS SIGNED) AS total
-                            FROM event_participants ep
-                            JOIN all_players ap
-                                ON ap.uuid = ep.participant_uuid
-                            LEFT JOIN (
-                                SELECT
-                                    se.participant_uuid,
-                                    SUM(
-                                        CASE
-                                            WHEN se.session_id IS NULL THEN se.points_base
-                                            WHEN gs.session_undone = FALSE THEN se.points_base
-                                            ELSE 0
-                                        END
-                                    ) AS total
-                                FROM score_events se
-                                LEFT JOIN game_sessions gs
-                                    ON gs.id = se.session_id
-                                WHERE se.event_id = ?
-                                GROUP BY se.participant_uuid
-                            ) se
-                                ON se.participant_uuid = ep.participant_uuid
-                            WHERE ep.event_id = ?
-                            """,
-                    eventId,
-                    eventId
-            );
-            
-            // rebuild admins
-            activeTeamsDao.executeRaw("""
-                            INSERT INTO active_admins (uuid)
-                            SELECT
-                            	ea.uuid
-                            FROM event_admins ea
-                            WHERE ea.event_id = ?
-                            """,
-                    eventId
-            );
-            
-            incrementActiveVersion();
-            return null;
-        });
+    public CompletableFuture<Void> rebuildEventMode(@NotNull String eventId) {
+        return CompletableFuture.runAsync(() -> {
+                    try {
+                        TransactionManager.callInTransaction(activeTeamsDao.getConnectionSource(), () -> {
+                            // clear
+                            activeTeamsDao.executeRaw("DELETE FROM in_game_participants");
+                            activeTeamsDao.executeRaw("DELETE FROM in_game_teams");
+                            activeTeamsDao.executeRaw("DELETE FROM active_participants");
+                            activeTeamsDao.executeRaw("DELETE FROM active_teams");
+                            activeTeamsDao.executeRaw("DELETE FROM active_admins");
+                            
+                            // rebuild teams
+                            activeTeamsDao.executeRaw("""
+                                            INSERT INTO active_teams (team_id, display_name, color, score)
+                                            SELECT
+                                                et.team_id,
+                                                et.display_name,
+                                                et.color,
+                                                CAST(COALESCE(se.total, 0) AS SIGNED) AS total
+                                            FROM event_teams et
+                                            LEFT JOIN (
+                                                SELECT
+                                                    se.team_id,
+                                                    SUM(
+                                                        CASE
+                                                            WHEN se.session_id IS NULL THEN se.points_base
+                                                            WHEN gs.session_undone = FALSE THEN FLOOR(se.points_base * gs.multiplier)
+                                                            ELSE 0
+                                                        END
+                                                    ) AS total
+                                                FROM score_events se
+                                                LEFT JOIN game_sessions gs
+                                                    ON gs.id = se.session_id
+                                                WHERE se.event_id = ?
+                                                GROUP BY se.team_id
+                                            ) se
+                                                ON se.team_id = et.team_id
+                                            WHERE et.event_id = ?
+                                            """,
+                                    eventId,
+                                    eventId
+                            );
+                            
+                            // rebuild participants
+                            activeTeamsDao.executeRaw("""
+                                            INSERT INTO active_participants (participant_uuid, team_id, ign, score)
+                                            SELECT
+                                                ep.participant_uuid,
+                                                ep.team_id,
+                                                ap.ign,
+                                                CAST(COALESCE(se.total, 0) AS SIGNED) AS total
+                                            FROM event_participants ep
+                                            JOIN all_players ap
+                                                ON ap.uuid = ep.participant_uuid
+                                            LEFT JOIN (
+                                                SELECT
+                                                    se.participant_uuid,
+                                                    SUM(
+                                                        CASE
+                                                            WHEN se.session_id IS NULL THEN se.points_base
+                                                            WHEN gs.session_undone = FALSE THEN se.points_base
+                                                            ELSE 0
+                                                        END
+                                                    ) AS total
+                                                FROM score_events se
+                                                LEFT JOIN game_sessions gs
+                                                    ON gs.id = se.session_id
+                                                WHERE se.event_id = ?
+                                                GROUP BY se.participant_uuid
+                                            ) se
+                                                ON se.participant_uuid = ep.participant_uuid
+                                            WHERE ep.event_id = ?
+                                            """,
+                                    eventId,
+                                    eventId
+                            );
+                            
+                            // rebuild admins
+                            activeTeamsDao.executeRaw("""
+                                            INSERT INTO active_admins (uuid)
+                                            SELECT
+                                                ea.uuid
+                                            FROM event_admins ea
+                                            WHERE ea.event_id = ?
+                                            """,
+                                    eventId
+                            );
+                            
+                            incrementActiveVersion();
+                            return null;
+                        });
+                    } catch (SQLException e) {
+                        throw new CompletionException(e);
+                    }
+                }, databaseExecutor)
+                .exceptionally(e -> {
+                    throw new CompletionException("A database error occurred rebuilding event mode", e);
+                });
     }
     
     /**

--- a/src/main/java/org/braekpo1nt/mctmanager/database/service/ScoreService.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/database/service/ScoreService.java
@@ -60,15 +60,9 @@ public class ScoreService {
         }
     }
     
-    // TODO: make these methods throw their exceptions for later handling by callers and double check use of return values
-    public @Nullable GameSession createGameSession(@NotNull GameSession gameSession) {
-        try {
-            gameSessionDao.create(gameSession);
-            return gameSession;
-        } catch (SQLException e) {
-            Main.logger().log(Level.SEVERE, String.format("Error creating GameSession %s", gameSession), e);
-            return null;
-        }
+    public @NotNull GameSession createGameSession(@NotNull GameSession gameSession) throws SQLException {
+        gameSessionDao.create(gameSession);
+        return gameSession;
     }
     
     public void setGameSessionEndDate(int id, @NotNull Date endTime) throws SQLException {

--- a/src/main/java/org/braekpo1nt/mctmanager/games/base/DuoGameBase.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/base/DuoGameBase.java
@@ -16,6 +16,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 @Getter
 public abstract class DuoGameBase<P extends ParticipantData, T extends ScoredTeamData<P> & Affiliated, QP extends QuitDataBase, QT extends QuitDataBase, S extends GameStateBase<P, T>> extends GameBase<P, T, QP, QT, S> {
@@ -65,11 +66,10 @@ public abstract class DuoGameBase<P extends ParticipantData, T extends ScoredTea
     }
     
     /**
-     * @param newParticipants the newParticipants
-     * @param newAdmins the newAdmins
+     * {@inheritDoc}
      */
     @Override
-    protected void start(@NotNull Collection<Team> newTeams, @NotNull Collection<Participant> newParticipants, @NotNull List<Player> newAdmins) {
+    protected CompletableFuture<Void> start(@NotNull Collection<Team> newTeams, @NotNull Collection<Participant> newParticipants, @NotNull List<Player> newAdmins) {
         teams.put(northTeam.getTeamId(), northTeam);
         setupTeamOptions(northTeam);
         tabList.addTeam(northTeam.getTeamId(), northTeam.getDisplayName(), northTeam.getColor());
@@ -84,13 +84,13 @@ public abstract class DuoGameBase<P extends ParticipantData, T extends ScoredTea
             String teamId = team.getTeamId();
             return !teamId.equals(northTeam.getTeamId()) && !teamId.equals(southTeam.getTeamId());
         }).toList();
-        super.start(spectatorTeams, newParticipants, newAdmins);
+        return super.start(spectatorTeams, newParticipants, newAdmins);
     }
     
     @Override
-    public void onJoin(@NotNull Team newTeam, @NotNull Participant participant) {
+    public CompletableFuture<Void> onJoin(@NotNull Team newTeam, @NotNull Participant participant) {
         if (teams.containsKey(newTeam.getTeamId())) {
-            return;
+            return CompletableFuture.completedFuture(null);
         }
         Affiliation affiliation = getAffiliation(newTeam.getTeamId());
         switch (affiliation) {
@@ -105,9 +105,11 @@ public abstract class DuoGameBase<P extends ParticipantData, T extends ScoredTea
                 state.onTeamRejoin(southTeam);
             }
             case SPECTATOR -> {
-                super.onJoin(newTeam, participant);
+                return super.onJoin(newTeam, participant);
             }
         }
+        // TODO: should onTeamRejoin return completableFuture?
+        return CompletableFuture.completedFuture(null);
     }
     
     /**
@@ -116,12 +118,13 @@ public abstract class DuoGameBase<P extends ParticipantData, T extends ScoredTea
      * @param teamId the teamId that quit
      */
     @Override
-    public void onTeamQuit(@NotNull String teamId) {
+    public CompletableFuture<Void> onTeamQuit(@NotNull String teamId) {
         T team = teams.get(teamId);
         if (team == null || team.size() > 0) {
-            return;
+            return CompletableFuture.completedFuture(null);
         }
         Affiliation affiliation = getAffiliation(teamId);
+        // TODO: this operation, and the equivalent one for joining, makes it seem like some quit logic isn't being called properly for north and south team quitting
         switch (affiliation) {
             case NORTH -> {
                 state.onTeamQuit(northTeam);
@@ -132,10 +135,11 @@ public abstract class DuoGameBase<P extends ParticipantData, T extends ScoredTea
                 teams.remove(team.getTeamId());
             }
             case SPECTATOR -> {
-                super.onTeamQuit(teamId);
+                return super.onTeamQuit(teamId);
             }
         }
         resetTeamOptions(team);
+        return CompletableFuture.completedFuture(null);
     }
     
     

--- a/src/main/java/org/braekpo1nt/mctmanager/games/base/GameBase.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/base/GameBase.java
@@ -64,6 +64,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 
 /**
@@ -182,8 +183,9 @@ public abstract class GameBase<P extends ParticipantData, T extends ScoredTeamDa
      * @param newTeams the teams going into the game
      * @param newParticipants the participants going into the game
      * @param newAdmins the admins going into the game
+     * @return the future containing database operations associated with the start of the game
      */
-    protected void start(@NotNull Collection<Team> newTeams, @NotNull Collection<Participant> newParticipants, @NotNull List<Player> newAdmins) {
+    protected CompletableFuture<Void> start(@NotNull Collection<Team> newTeams, @NotNull Collection<Participant> newParticipants, @NotNull List<Player> newAdmins) {
         plugin.getServer().getPluginManager().registerEvents(this, plugin);
         listeners.forEach(listener -> listener.register(plugin));
         for (Team newTeam : newTeams) {
@@ -213,8 +215,10 @@ public abstract class GameBase<P extends ParticipantData, T extends ScoredTeamDa
         _initializeAdminSidebar();
         // admin end
         
+        this.state = getStartState();
+        this.state.enter();
         // database start
-        plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
+        return CompletableFuture.runAsync(() -> {
             try {
                 // update the live representation of the players and teams
                 gameManager.getGameStateService().addInGameParticipantsAndTeams(
@@ -250,10 +254,8 @@ public abstract class GameBase<P extends ParticipantData, T extends ScoredTeamDa
             } catch (SQLException e) {
                 reportSQLException("initializing in_game_* tables for game", e);
             }
-        });
+        }, plugin.getDatabaseExecutor());
         // database end
-        this.state = getStartState();
-        this.state.enter();
     }
     
     /**
@@ -281,16 +283,16 @@ public abstract class GameBase<P extends ParticipantData, T extends ScoredTeamDa
      * then calls {@link GameStateBase#enter()} on the new {@link #state}
      * @param state assign a state to this game
      */
-    // TODO: remove final
-    public final void setState(@NotNull S state) {
+    public void setState(@NotNull S state) {
         this.state.exit();
         this.state = state;
         this.state.enter();
     }
     
     // cleanup start
+    // TODO: return result is never used
     @Override
-    public void stop() {
+    public CompletableFuture<Void> stop() {
         HandlerList.unregisterAll(this);
         listeners.forEach(GameListener::unregister);
         listeners.clear();
@@ -320,17 +322,17 @@ public abstract class GameBase<P extends ParticipantData, T extends ScoredTeamDa
         }
         storedGameRules.clear();
         cleanup();
-        plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
+        gameManager.gameIsOver(gameSessionId, getGameInstanceId(), teamScores, participantScores, participants.values().stream().map(Participant::getUniqueId).toList(), admins);
+        participants.clear();
+        admins.clear();
+        Main.logger().info("Stopping " + type.getTitle());
+        return CompletableFuture.runAsync(() -> {
             try {
                 gameManager.getGameStateService().removeInGameTeamsAndParticipants(gameSessionId);
             } catch (SQLException e) {
                 reportSQLException("clearing the active game entries for this game", e);
             }
-        });
-        gameManager.gameIsOver(gameSessionId, getGameInstanceId(), teamScores, participantScores, participants.values().stream().map(Participant::getUniqueId).toList(), admins);
-        participants.clear();
-        admins.clear();
-        Main.logger().info("Stopping " + type.getTitle());
+        }, plugin.getDatabaseExecutor());
     }
     
     /**
@@ -521,14 +523,16 @@ public abstract class GameBase<P extends ParticipantData, T extends ScoredTeamDa
     // quit/join start
     
     @Override
-    public void onJoin(@NotNull Team team, @NotNull Participant participant) {
-        onTeamJoin(team);
-        onParticipantJoin(participant);
+    public CompletableFuture<Void> onJoin(@NotNull Team team, @NotNull Participant participant) {
+        CompletableFuture<Void> tJoinFuture = onTeamJoin(team);
+        CompletableFuture<Void> pJoinFuture = onParticipantJoin(participant);
+        return tJoinFuture
+                .thenCompose(v -> pJoinFuture);
     }
     
-    protected void onTeamJoin(Team newTeam) {
+    protected CompletableFuture<Void> onTeamJoin(Team newTeam) {
         if (teams.containsKey(newTeam.getTeamId())) {
-            return;
+            return CompletableFuture.completedFuture(null);
         }
         QT quitTeam = teamQuitDatas.remove(newTeam.getTeamId());
         T team;
@@ -544,7 +548,7 @@ public abstract class GameBase<P extends ParticipantData, T extends ScoredTeamDa
             tabList.addTeam(team.getTeamId(), team.getDisplayName(), team.getColor());
             state.onNewTeamJoin(team);
         }
-        plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
+        return CompletableFuture.runAsync(() -> {
             try {
                 gameManager.getGameStateService().addOrUpdateTeam(InGameTeam.builder()
                         .teamId(team.getTeamId())
@@ -554,10 +558,10 @@ public abstract class GameBase<P extends ParticipantData, T extends ScoredTeamDa
             } catch (SQLException e) {
                 reportSQLException("joining team to game and updating in-game table", e);
             }
-        });
+        }, plugin.getDatabaseExecutor());
     }
     
-    protected void onParticipantJoin(Participant newParticipant) {
+    protected CompletableFuture<Void> onParticipantJoin(Participant newParticipant) {
         T team = teams.get(newParticipant.getTeamId());
         QP quitData = quitDatas.remove(newParticipant.getParticipantID());
         newParticipant.setGameMode(GameMode.ADVENTURE);
@@ -576,7 +580,11 @@ public abstract class GameBase<P extends ParticipantData, T extends ScoredTeamDa
             addParticipant(participant, team);
             state.onNewParticipantJoin(participant, team);
         }
-        plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
+        // update the UI
+        sidebar.updateLine(participant.getUniqueId(), "title", title);
+        displayScore(participant);
+        displayScore(team);
+        return CompletableFuture.runAsync(() -> {
             try {
                 gameManager.getGameStateService().addOrUpdateParticipant(InGameParticipant.builder()
                         .participantUUID(participant.getUniqueId().toString())
@@ -597,31 +605,22 @@ public abstract class GameBase<P extends ParticipantData, T extends ScoredTeamDa
             } catch (SQLException e) {
                 reportSQLException("joining participant to game and updating in-game database", e);
             }
-        });
-        // update the UI
-        sidebar.updateLine(participant.getUniqueId(), "title", title);
-        displayScore(participant);
-        displayScore(team);
+        }, plugin.getDatabaseExecutor());
     }
     
     @Override
-    public void onQuit(@NotNull String teamId, @NotNull UUID participantUUID) {
-        onParticipantQuit(participantUUID);
-        onTeamQuit(teamId);
+    public CompletableFuture<Void> onQuit(@NotNull String teamId, @NotNull UUID participantUUID) {
+        CompletableFuture<Void> pQuitFuture = onParticipantQuit(participantUUID);
+        CompletableFuture<Void> tQuitFuture = onTeamQuit(teamId);
+        return pQuitFuture
+                .thenCompose(v -> tQuitFuture);
     }
     
-    protected void onParticipantQuit(@NotNull UUID participantUUID) {
+    protected CompletableFuture<Void> onParticipantQuit(@NotNull UUID participantUUID) {
         P participant = participants.get(participantUUID);
         if (participant == null) {
-            return;
+            return CompletableFuture.completedFuture(null);
         }
-        plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
-            try {
-                gameManager.getGameStateService().deleteInGameParticipant(participantUUID.toString());
-            } catch (SQLException e) {
-                reportSQLException("quitting participant from game and removing from the in-game table", e);
-            }
-        });
         T team = teams.get(participant.getTeamId());
         state.onParticipantQuit(participant, team);
         participants.remove(participantUUID);
@@ -630,28 +629,36 @@ public abstract class GameBase<P extends ParticipantData, T extends ScoredTeamDa
         tabList.setParticipantGrey(participant.getParticipantID(), true);
         participant.setGameMode(GameMode.ADVENTURE);
         _resetParticipant(participant, team);
+        return CompletableFuture.runAsync(() -> {
+            try {
+                gameManager.getGameStateService().deleteInGameParticipant(participantUUID.toString());
+            } catch (SQLException e) {
+                reportSQLException("quitting participant from game and removing from the in-game table", e);
+            }
+        }, plugin.getDatabaseExecutor());
     }
     
-    protected void onTeamQuit(@NotNull String teamId) {
+    protected CompletableFuture<Void> onTeamQuit(@NotNull String teamId) {
         T team = teams.get(teamId);
         if (team == null || team.size() > 0) {
-            return;
+            return CompletableFuture.completedFuture(null);
         }
         // no more members on the team
-        plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
+        state.onTeamQuit(team);
+        teams.remove(team.getTeamId());
+        teamQuitDatas.put(team.getTeamId(), getQuitData(team));
+        resetTeamOptions(team);
+        CompletableFuture<Void> chain = CompletableFuture.completedFuture(null);
+        if (teams.isEmpty()) {
+            chain = chain.thenCompose(v -> stop());
+        }
+        return chain.thenRunAsync(() -> {
             try {
                 gameManager.getGameStateService().deleteInGameTeam(teamId);
             } catch (SQLException e) {
                 reportSQLException("quitting team from game and removing from the in-game table", e);
             }
-        });
-        state.onTeamQuit(team);
-        teams.remove(team.getTeamId());
-        teamQuitDatas.put(team.getTeamId(), getQuitData(team));
-        resetTeamOptions(team);
-        if (teams.isEmpty()) {
-            stop();
-        }
+        }, plugin.getDatabaseExecutor());
     }
     // quit/join end
     
@@ -816,15 +823,16 @@ public abstract class GameBase<P extends ParticipantData, T extends ScoredTeamDa
      * <p>{@link #sidebar} will also be updated to reflect the score. </p>
      * @param participant the participant to be awarded personal points
      * @param points the points to be awarded (un-multiplied, base points)
+     * @return a future containing database operations
      */
-    public void awardPoints(P participant, int points, String description) {
+    public CompletableFuture<Void> awardPoints(P participant, int points, String description) {
         int multiplied = (int) (points * gameManager.getMultiplier());
         participant.awardPoints(points);
         T team = teams.get(participant.getTeamId());
         team.addPoints(multiplied);
         displayScore(participant);
         displayScore(team);
-        plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
+        return CompletableFuture.runAsync(() -> {
             Date date = new Date();
             gameManager.logScoreEvent(ScoreEvent.builder()
                     .sourceType(ScoreEvent.SourceType.GAME)
@@ -841,7 +849,7 @@ public abstract class GameBase<P extends ParticipantData, T extends ScoredTeamDa
             } catch (SQLException e) {
                 reportSQLException("update in-game participant score", e);
             }
-        });
+        }, plugin.getDatabaseExecutor());
     }
     
     /**
@@ -850,12 +858,13 @@ public abstract class GameBase<P extends ParticipantData, T extends ScoredTeamDa
      * <p>{@link #sidebar} will also be updated to reflect the score</p>
      * @param team the team to award the points to
      * @param points the points to be awarded (un-multiplied, base points)
+     * @return a future containing database operations
      */
-    public void awardPoints(T team, int points, String description) {
+    public CompletableFuture<Void> awardPoints(T team, int points, String description) {
         int multiplied = (int) (points * gameManager.getMultiplier());
         team.awardPoints(multiplied);
         displayScore(team);
-        plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
+        return CompletableFuture.runAsync(() -> {
             Date date = new Date();
             gameManager.logScoreEvent(ScoreEvent.builder()
                     .sourceType(ScoreEvent.SourceType.GAME)
@@ -871,7 +880,7 @@ public abstract class GameBase<P extends ParticipantData, T extends ScoredTeamDa
             } catch (SQLException e) {
                 reportSQLException("update in-game team score", e);
             }
-        });
+        }, plugin.getDatabaseExecutor());
     }
     
     /**
@@ -881,8 +890,9 @@ public abstract class GameBase<P extends ParticipantData, T extends ScoredTeamDa
      * <p>{@link #sidebar} will also be updated to reflect the score. </p>
      * @param awardedParticipants the participants to be awarded personal points
      * @param points the points to be awarded (un-multiplied, base points)
+     * @return a future containing database operations
      */
-    public void awardParticipantPoints(Collection<P> awardedParticipants, int points, String description) {
+    public CompletableFuture<Void> awardParticipantPoints(Collection<P> awardedParticipants, int points, String description) {
         int multiplied = (int) (points * gameManager.getMultiplier());
         Set<T> awardedTeams = new HashSet<>();
         for (P participant : awardedParticipants) {
@@ -891,7 +901,9 @@ public abstract class GameBase<P extends ParticipantData, T extends ScoredTeamDa
             team.addPoints(multiplied);
             awardedTeams.add(team);
         }
-        plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
+        displayParticipantScores(awardedParticipants);
+        displayTeamScores(awardedTeams);
+        return CompletableFuture.runAsync(() -> {
             Date date = new Date();
             gameManager.logScoreEvents(awardedParticipants.stream()
                     .map(participant -> ScoreEvent.builder()
@@ -910,9 +922,7 @@ public abstract class GameBase<P extends ParticipantData, T extends ScoredTeamDa
             } catch (Exception e) {
                 reportSQLException("bulk update in-game participant and team score", new SQLException(e));
             }
-        });
-        displayParticipantScores(awardedParticipants);
-        displayTeamScores(awardedTeams);
+        }, plugin.getDatabaseExecutor());
     }
     
     /**
@@ -921,14 +931,15 @@ public abstract class GameBase<P extends ParticipantData, T extends ScoredTeamDa
      * <p>{@link #sidebar} will also be updated to reflect the score</p>
      * @param awardedTeams the teams to award the points to
      * @param points the points to be awarded (un-multiplied, base points)
+     * @return a future containing database operations
      */
-    public void awardTeamPoints(Collection<T> awardedTeams, int points, String description) {
+    public CompletableFuture<Void> awardTeamPoints(Collection<T> awardedTeams, int points, String description) {
         int multiplied = (int) (points * gameManager.getMultiplier());
         for (T team : awardedTeams) {
             team.awardPoints(multiplied);
         }
         displayTeamScores(awardedTeams);
-        plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
+        return CompletableFuture.runAsync(() -> {
             Date date = new Date();
             gameManager.logScoreEvents(awardedTeams.stream()
                     .map(team -> ScoreEvent.builder()
@@ -946,7 +957,7 @@ public abstract class GameBase<P extends ParticipantData, T extends ScoredTeamDa
             } catch (Exception e) {
                 reportSQLException("bulk update in-game team score", new SQLException(e));
             }
-        });
+        }, plugin.getDatabaseExecutor());
     }
     // Award Points end
     

--- a/src/main/java/org/braekpo1nt/mctmanager/games/base/WandsDuoGameBase.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/base/WandsDuoGameBase.java
@@ -22,6 +22,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 public abstract class WandsDuoGameBase<P extends ParticipantData, T extends ScoredTeamData<P> & Affiliated, QP extends QuitDataBase, QT extends QuitDataBase, S extends GameStateBase<P, T>> extends DuoGameBase<P, T, QP, QT, S> {
     
@@ -77,15 +78,16 @@ public abstract class WandsDuoGameBase<P extends ParticipantData, T extends Scor
     }
     
     @Override
-    protected void start(@NotNull Collection<Team> newTeams, @NotNull Collection<Participant> newParticipants, @NotNull List<Player> newAdmins) {
-        super.start(newTeams, newParticipants, newAdmins);
+    protected CompletableFuture<Void> start(@NotNull Collection<Team> newTeams, @NotNull Collection<Participant> newParticipants, @NotNull List<Player> newAdmins) {
+        CompletableFuture<Void> startFuture = super.start(newTeams, newParticipants, newAdmins);
         startWandTick();
+        return startFuture;
     }
     
     @Override
-    public void stop() {
+    public CompletableFuture<Void> stop() {
         plugin.getServer().getScheduler().cancelTask(wandTickTaskId);
-        super.stop();
+        return super.stop();
     }
     
     /**

--- a/src/main/java/org/braekpo1nt/mctmanager/games/base/WandsGameBase.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/base/WandsGameBase.java
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 @Getter
 @Setter
@@ -78,15 +79,16 @@ public abstract class WandsGameBase<P extends ParticipantData, T extends ScoredT
     }
     
     @Override
-    protected void start(@NotNull Collection<Team> newTeams, @NotNull Collection<Participant> newParticipants, @NotNull List<Player> newAdmins) {
-        super.start(newTeams, newParticipants, newAdmins);
+    protected CompletableFuture<Void> start(@NotNull Collection<Team> newTeams, @NotNull Collection<Participant> newParticipants, @NotNull List<Player> newAdmins) {
+        CompletableFuture<Void> startFuture = super.start(newTeams, newParticipants, newAdmins);
         startWandTick();
+        return startFuture;
     }
     
     @Override
-    public void stop() {
+    public CompletableFuture<Void> stop() {
         plugin.getServer().getScheduler().cancelTask(wandTickTaskId);
-        super.stop();
+        return super.stop();
     }
     
     /**

--- a/src/main/java/org/braekpo1nt/mctmanager/games/game/colossalcombat/config/ColossalCombatConfigDTO.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/game/colossalcombat/config/ColossalCombatConfigDTO.java
@@ -257,7 +257,6 @@ record ColossalCombatConfigDTO(
      * @param antiSuffocation the duration (in ticks) to prevent players from walking over the area that would cause
      * them to suffocate in the concrete powder wall as the blocks fall. Careful, if this is not
      * long enough the players will suffocate, and if it's too long they'll get frustrated.
-     *                        TODO: implement a more automated version of this.
      */
     record Durations(int roundStarting, int roundOver, int gameOver, long antiSuffocation, int description) {
     }

--- a/src/main/java/org/braekpo1nt/mctmanager/games/game/farmrush/FarmRushGame.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/game/farmrush/FarmRushGame.java
@@ -71,6 +71,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 @Getter
 @Setter
@@ -338,9 +339,9 @@ public class FarmRushGame extends WandsGameBase<FarmRushParticipant, FarmRushTea
     }
     
     @Override
-    public void stop() {
+    public CompletableFuture<Void> stop() {
         removeArenas(teams.values().stream().map(FarmRushTeam::getArena).toList());
-        super.stop();
+        return super.stop();
     }
     
     @Override

--- a/src/main/java/org/braekpo1nt/mctmanager/games/game/footrace/editor/FootRaceEditor.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/game/footrace/editor/FootRaceEditor.java
@@ -156,7 +156,7 @@ public class FootRaceEditor extends EditorBase<FootRaceAdmin, FootRaceEditorStat
                                     .append(Component.text("Add checkpoint index "))
                                     .append(Component.text(newCheckpointIndex))
                                     .append(Component.text("/"))
-                                    .append(Component.text(config.getCheckpoints().size() - 1)) //TODO: is this correct numbers?
+                                    .append(Component.text(config.getCheckpoints().size() - 1))
                                     .append(Component.text(". Max index is now "))
                                     .append(Component.text(config.getCheckpoints().size() - 1)))
                     );

--- a/src/main/java/org/braekpo1nt/mctmanager/games/game/interfaces/MCTGame.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/game/interfaces/MCTGame.java
@@ -9,6 +9,7 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * An MCT game.
@@ -16,11 +17,11 @@ import java.util.UUID;
 public interface MCTGame {
     GameType getType();
     
-    void stop();
+    CompletableFuture<Void> stop();
     
-    void onJoin(@NotNull Team team, @NotNull Participant participant);
+    CompletableFuture<Void> onJoin(@NotNull Team team, @NotNull Participant participant);
     
-    void onQuit(@NotNull String teamId, @NotNull UUID participantUUID);
+    CompletableFuture<Void> onQuit(@NotNull String teamId, @NotNull UUID participantUUID);
     
     void onAdminJoin(Player admin);
     

--- a/src/main/java/org/braekpo1nt/mctmanager/games/game/parkourpathway/editor/ParkourPathwayEditor.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/game/parkourpathway/editor/ParkourPathwayEditor.java
@@ -103,7 +103,7 @@ public class ParkourPathwayEditor extends EditorBase<ParkourAdmin, ParkourPathwa
                                     .append(Component.text("Add puzzle index "))
                                     .append(Component.text(newPuzzleIndex))
                                     .append(Component.text("/"))
-                                    .append(Component.text(puzzles.size())) //TODO: is this correct numbers?
+                                    .append(Component.text(puzzles.size()))
                                     .append(Component.text(". Max index is now "))
                                     .append(Component.text(puzzles.size() + 1)))
                     );
@@ -120,7 +120,7 @@ public class ParkourPathwayEditor extends EditorBase<ParkourAdmin, ParkourPathwa
                             selectResult,
                             CommandResult.success(Component.empty()
                                     .append(Component.text("Remove puzzle index "))
-                                    .append(Component.text(admin.getCurrentPuzzle())) // TODO: is the the right number?
+                                    .append(Component.text(admin.getCurrentPuzzle()))
                                     .append(Component.text("/"))
                                     .append(Component.text(puzzles.size()))
                                     .append(Component.text(". Max index is now "))

--- a/src/main/java/org/braekpo1nt/mctmanager/games/gamemanager/GameManager.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/gamemanager/GameManager.java
@@ -56,6 +56,8 @@ import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scoreboard.Scoreboard;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -72,6 +74,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 
@@ -89,6 +93,8 @@ public class GameManager implements Listener {
     private final ScoreService scoreService;
     @Getter
     private final EventService eventService;
+    @Getter
+    private final Executor mainThreadExecutor;
     @Getter
     private final GameStateService gameStateService;
     // TODO: remove these getter and setter and make this a map like activeGames
@@ -146,13 +152,14 @@ public class GameManager implements Listener {
     @Getter
     private @NotNull HubConfig config;
     
-    public GameManager(Main plugin,
-                       Scoreboard mctScoreboard,
+    public GameManager(@NotNull Main plugin,
+                       @NotNull Scoreboard mctScoreboard,
                        @NotNull GameStateStorageUtil gameStateStorageUtil,
                        @NotNull SidebarFactory sidebarFactory,
                        @NotNull HubConfig config,
                        @NotNull Database database,
-                       @NotNull GameStateService gameStateService) {
+                       @NotNull GameStateService gameStateService,
+                       @NotNull Executor mainThreadExecutor) {
         this.plugin = plugin;
         plugin.getServer().getPluginManager().registerEvents(this, plugin);
         this.mctScoreboard = mctScoreboard;
@@ -167,6 +174,7 @@ public class GameManager implements Listener {
                 databaseMode,
                 database
         );
+        this.mainThreadExecutor = mainThreadExecutor;
         this.gameStateService = gameStateService;
         this.sidebarFactory = sidebarFactory;
         this.config = config;
@@ -186,6 +194,7 @@ public class GameManager implements Listener {
                 .adminEditors(this.adminEditors)
                 .plugin(this.plugin)
                 .gameStateStorageUtil(this.gameStateStorageUtil)
+                .mainThreadExecutor(this.mainThreadExecutor)
                 .sidebarFactory(this.sidebarFactory)
                 .sidebar(this.sidebar)
                 .leaderboardManagers(this.leaderboardManagers)
@@ -219,7 +228,7 @@ public class GameManager implements Listener {
             } catch (SQLException e) {
                 reportGameStateException("Assign the system_state description", e);
             }
-        });
+        }, plugin.getDatabaseExecutor());
     }
     
     public CommandResult switchMode(@NotNull Mode mode) {
@@ -384,7 +393,7 @@ public class GameManager implements Listener {
         }
     }
     
-    private void resolveUUIDandIGNerrors(Player player) {
+    private @NotNull CompletableFuture<Void> resolveUUIDandIGNerrors(Player player) {
         /*
         - check if the player's UUID is in the game state
           - if their uuid IS in the game state
@@ -412,7 +421,7 @@ public class GameManager implements Listener {
             String incorrectIGN = existingParticipant.getName();
             if (incorrectIGN.equals(correctIGN)) {
                 // their name is correct, nothing to do
-                return;
+                return CompletableFuture.completedFuture(null);
             }
             // if their name is incorrect
             // update the ign in allParticipants
@@ -434,7 +443,7 @@ public class GameManager implements Listener {
             } catch (SQLException e) {
                 reportGameStateException(String.format("migrate the ign of the player with uuid \"%s\" from \"%s\" to the correct ign \"%s\"", correctUUID, incorrectIGN, correctIGN), e);
             }
-            return;
+            return CompletableFuture.completedFuture(null);
         }
         // if the UUID is NOT in the game state
         OfflineParticipant offlineParticipantWithIGN = getOfflineParticipant(correctIGN);
@@ -446,20 +455,30 @@ public class GameManager implements Listener {
             } catch (SQLException e) {
                 reportGameStateException(String.format("register new player with name \"%s\" and UUID \"%s\" in the database", correctIGN, correctUUID), e);
             }
-            return;
+            return CompletableFuture.completedFuture(null);
         }
         // the participant with the wrong UUID but the correct IGN is in the game state
         // we need to migrate the uuid
         UUID incorrectUUID = offlineParticipantWithIGN.getUniqueId();
-        leaveParticipant(offlineParticipantWithIGN);
-        // resolve them in the database
-        try {
-            gameStateService.migrateUUID(incorrectUUID.toString(), correctUUID.toString(), correctIGN);
-        } catch (SQLException e) {
-            reportGameStateException(String.format("migrate player \"%s\" from UUID \"%s\" to the correct uuid \"%s\" in the database", correctIGN, incorrectUUID, correctUUID), e);
-        }
-        MCTTeam team = teams.get(offlineParticipantWithIGN.getTeamId());
-        state.joinParticipantToTeam(correctUUID, correctIGN, team);
+        return leaveParticipant(offlineParticipantWithIGN)
+                .thenRunAsync(() -> {
+                    // resolve them in the database
+                    try {
+                        gameStateService.migrateUUID(incorrectUUID.toString(), correctUUID.toString(), correctIGN);
+                    } catch (SQLException e) {
+                        throw new CompletionException(e);
+                    }
+                }, plugin.getDatabaseExecutor())
+                .exceptionally(e -> {
+                    reportGameStateException(String.format("migrate player \"%s\" from UUID \"%s\" to the correct uuid \"%s\" in the database", correctIGN, incorrectUUID, correctUUID), e);
+                    return null;
+                })
+                .thenComposeAsync(v -> {
+                    MCTTeam team = teams.get(offlineParticipantWithIGN.getTeamId());
+                    return state.joinOfflineParticipantToTeam(correctUUID, correctIGN, team);
+                }, mainThreadExecutor)
+                // TODO: the CommandResult of joinOfflineParticipant to team is ignored in this case, do something with it 
+                .thenApply(ignored -> null);
     }
     
     /**
@@ -595,19 +614,24 @@ public class GameManager implements Listener {
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
         Player player = event.getPlayer();
-        resolveUUIDandIGNerrors(player);
-        
-        if (isAdmin(player.getUniqueId())) {
-            state.onAdminJoin(event, player);
-            return;
-        }
-        OfflineParticipant offlineParticipant = allParticipants.get(player.getUniqueId());
-        if (offlineParticipant != null) {
-            MCTParticipant participant = new MCTParticipant(offlineParticipant, player);
-            state.onParticipantJoin(event, participant);
-            return;
-        }
-        state.onNonJoin(player);
+        resolveUUIDandIGNerrors(player)
+                .thenComposeAsync(v -> {
+                    if (isAdmin(player.getUniqueId())) {
+                        state.onAdminJoin(event, player);
+                        return CompletableFuture.completedFuture(null);
+                    }
+                    OfflineParticipant offlineParticipant = allParticipants.get(player.getUniqueId());
+                    if (offlineParticipant != null) {
+                        MCTParticipant participant = new MCTParticipant(offlineParticipant, player);
+                        return state.onParticipantJoin(event, participant);
+                    }
+                    state.onNonJoin(player);
+                    return CompletableFuture.completedFuture(null);
+                }, mainThreadExecutor)
+                .exceptionally(e -> {
+                    Main.logger().log(Level.SEVERE, String.format("An error occurred when the player %s joined (with UUID %s)", player.getName(), player.getUniqueId()), e);
+                    return null;
+                });
     }
     
     @EventHandler
@@ -660,10 +684,10 @@ public class GameManager implements Listener {
         return mctScoreboard;
     }
     
-    public CommandResult joinParticipantToGame(@NotNull GameType gameType, @Nullable String configFile, @NotNull UUID uuid) {
+    public CompletableFuture<CommandResult> joinParticipantToGame(@NotNull GameType gameType, @Nullable String configFile, @NotNull UUID uuid) {
         MCTParticipant mctParticipant = onlineParticipants.get(uuid);
         if (mctParticipant == null) {
-            return CommandResult.failure(Component.text("You are not a participant"));
+            return CommandResult.failure(Component.text("You are not a participant")).asFuture();
         }
         return state.joinParticipantToGame(gameType, configFile, mctParticipant);
     }
@@ -695,10 +719,10 @@ public class GameManager implements Listener {
         return state.joinAdminToGame(gameType, configFile, admin);
     }
     
-    public CommandResult returnParticipantToHub(@NotNull UUID uuid) {
+    public CompletableFuture<CommandResult> returnParticipantToHub(@NotNull UUID uuid) {
         MCTParticipant mctParticipant = onlineParticipants.get(uuid);
         if (mctParticipant == null) {
-            return CommandResult.failure(Component.text("You are not a participant"));
+            return CommandResult.failure(Component.text("You are not a participant")).asFuture();
         }
         return state.returnParticipantToHub(mctParticipant);
     }
@@ -717,7 +741,7 @@ public class GameManager implements Listener {
         return state.createSidebar();
     }
     
-    public @NotNull CommandResult loadGameState() {
+    public @NotNull CompletableFuture<CommandResult> loadGameState() {
         return state.loadGameState();
     }
     
@@ -725,7 +749,7 @@ public class GameManager implements Listener {
         return state.eventIsActive();
     }
     
-    public CommandResult startGame(@NotNull Set<String> teamIds, @NotNull List<Player> gameAdmins, @NotNull GameType gameType, @NotNull String configFile) {
+    public CompletableFuture<CommandResult> startGame(@NotNull Set<String> teamIds, @NotNull List<Player> gameAdmins, @NotNull GameType gameType, @NotNull String configFile) {
         return state.startGame(teamIds, gameAdmins, gameType, configFile);
     }
     
@@ -738,41 +762,44 @@ public class GameManager implements Listener {
         return eventService.getEventIds();
     }
     
-    public CommandResult createEvent(String eventId, Date eventDate, String plainTextName, Component componentName, boolean canonical) {
+    public CompletableFuture<CommandResult> createEvent(String eventId, Date eventDate, String plainTextName, Component componentName, boolean canonical) {
         Date now = new Date();
-        try {
-            boolean uniqueKey = eventService.addEventInfo(EventInfo.builder()
-                    .eventId(eventId)
-                    .plainTextName(plainTextName)
-                    .componentName(componentName)
-                    .eventDate(eventDate)
-                    .createdAt(now)
-                    .modifiedAt(now)
-                    .startedAt(null)
-                    .endedAt(null)
-                    .winnerTeamId(null)
-                    .canonical(canonical)
-                    .standingsVersion(0)
-                    .build());
-            if (!uniqueKey) {
-                return CommandResult.failure(Component.empty()
-                        .append(Component.text("An event already exists with the given id: "))
-                        .append(Component.text(eventId)
-                                .decorate(TextDecoration.BOLD))
-                );
-            }
-        } catch (SQLException e) {
-            throw new RuntimeException(e);
-        }
-        return CommandResult.success(Component.empty()
-                .append(Component.text("Created event \""))
-                .append(Component.text(eventId))
-                .append(Component.text("\" with plain-text name \""))
-                .append(Component.text(plainTextName))
-                .append(Component.text("\" and Component name \""))
-                .append(componentName)
-                .append(Component.text("\""))
-        );
+        return CompletableFuture.supplyAsync(() -> {
+                    try {
+                        boolean uniqueKey = eventService.addEventInfo(EventInfo.builder()
+                                .eventId(eventId)
+                                .plainTextName(plainTextName)
+                                .componentName(componentName)
+                                .eventDate(eventDate)
+                                .createdAt(now)
+                                .modifiedAt(now)
+                                .startedAt(null)
+                                .endedAt(null)
+                                .winnerTeamId(null)
+                                .canonical(canonical)
+                                .standingsVersion(0)
+                                .build());
+                        if (!uniqueKey) {
+                            return CommandResult.failure(Component.empty()
+                                    .append(Component.text("An event already exists with the given id: "))
+                                    .append(Component.text(eventId)
+                                            .decorate(TextDecoration.BOLD))
+                            );
+                        }
+                    } catch (SQLException e) {
+                        throw new CompletionException(e);
+                    }
+                    return CommandResult.success(Component.empty()
+                            .append(Component.text("Created event \""))
+                            .append(Component.text(eventId))
+                            .append(Component.text("\" with plain-text name \""))
+                            .append(Component.text(plainTextName))
+                            .append(Component.text("\" and Component name \""))
+                            .append(componentName)
+                            .append(Component.text("\""))
+                    );
+                }, plugin.getDatabaseExecutor())
+                .exceptionally(e -> CommandResult.throwable("add event info", e));
     }
     
     /**
@@ -816,11 +843,11 @@ public class GameManager implements Listener {
         }
     }
     
-    public CommandResult startEvent(@NotNull EventInfo eventInfo, int maxGames, int currentGameNumber) {
+    public CompletableFuture<CommandResult> startEvent(@NotNull EventInfo eventInfo, int maxGames, int currentGameNumber) {
         return state.startEvent(eventInfo, maxGames, currentGameNumber);
     }
     
-    public @NotNull CommandResult stopEvent() {
+    public @NotNull CompletableFuture<CommandResult> stopEvent() {
         return state.stopEvent();
     }
     
@@ -831,8 +858,23 @@ public class GameManager implements Listener {
      * @return a CommandResult indicating the success or failure of starting the game,
      * including a reason why the game didn't start if so.
      */
-    public CommandResult startGame(@NotNull GameType gameType, @NotNull String configFile) {
-        return state.startGame(teams.keySet(), onlineAdmins, gameType, configFile);
+    public CompletableFuture<CommandResult> startGame(@NotNull GameType gameType, @NotNull String configFile) {
+        return state.startGame(teams.keySet(), onlineAdmins, gameType, configFile); // TODO: this should call the other startGame() in this class or vice versa
+    }
+    
+    /**
+     * @deprecated just meant for a temporary test to make sure my fake thread safe checks work. Delete when found again
+     * and the associated test.
+     */
+    @Deprecated
+    public CompletableFuture<Void> illegalMove(Player player) {
+        return CompletableFuture.runAsync(() -> {
+                    player.addPotionEffect(new PotionEffect(PotionEffectType.INVISIBILITY, 1, 1));
+                }, plugin.getDatabaseExecutor())
+                .exceptionally(e -> {
+                    Main.logger().log(Level.SEVERE, "An error occurred during illegalMove", e);
+                    throw new CompletionException("an error occurred during illegalMove", e);
+                });
     }
     
     public CommandResult startEditor(@NotNull GameType gameType, @NotNull String configFile) {
@@ -915,14 +957,14 @@ public class GameManager implements Listener {
         return team.isOnline();
     }
     
-    public CommandResult stopGame(@NotNull GameType gameType, @Nullable String configFile) {
+    public CompletableFuture<CommandResult> stopGame(@NotNull GameType gameType, @Nullable String configFile) {
         return state.stopGame(gameType, configFile);
     }
     
     /**
      * Stop all active games, if there are any
      */
-    public CommandResult stopAllGames() {
+    public CompletableFuture<CommandResult> stopAllGames() {
         return state.stopAllGames();
     }
     
@@ -1002,7 +1044,7 @@ public class GameManager implements Listener {
      * Remove the given team from the game
      * @param teamId teamId of the team to remove
      */
-    public CommandResult removeTeam(String teamId) {
+    public CompletableFuture<CommandResult> removeTeam(String teamId) {
         return state.removeTeam(teamId);
     }
     
@@ -1013,7 +1055,7 @@ public class GameManager implements Listener {
      * @param colorString the string representing the color
      * @return the newly created team, or null if the given team already exists or could not be created
      */
-    public Team addTeam(String teamId, String teamDisplayName, String colorString) {
+    public CompletableFuture<Team> addTeam(String teamId, String teamDisplayName, String colorString) {
         return state.addTeam(teamId, teamDisplayName, colorString);
     }
     
@@ -1034,14 +1076,14 @@ public class GameManager implements Listener {
      * @param ign The name of the participant to join to the given team
      * @param teamId The teamId of the team to join the participant to.
      */
-    public CommandResult joinOfflineParticipant(@NotNull UUID uuid, @NotNull String ign, @NotNull String teamId) {
+    public CompletableFuture<CommandResult> joinOfflineParticipant(@NotNull UUID uuid, @NotNull String ign, @NotNull String teamId) {
         MCTTeam team = teams.get(teamId);
-        return state.joinParticipantToTeam(uuid, ign, team);
+        return state.joinOfflineParticipantToTeam(uuid, ign, team);
     }
     
-    public CommandResult joinOnlineParticipant(@NotNull Player player, @NotNull String teamId) {
+    public CompletableFuture<CommandResult> joinOnlineParticipant(@NotNull Player player, @NotNull String teamId) {
         MCTTeam team = teams.get(teamId);
-        return state.joinParticipantToTeam(player, team);
+        return state.joinOnlineParticipantToTeam(player, team);
     }
     
     /**
@@ -1061,7 +1103,7 @@ public class GameManager implements Listener {
      * If a game is running, and the player is online, removes that player from the game as well.
      * @param offlineParticipant The participant to remove from their team
      */
-    public CommandResult leaveParticipant(@NotNull OfflineParticipant offlineParticipant) {
+    public CompletableFuture<CommandResult> leaveParticipant(@NotNull OfflineParticipant offlineParticipant) {
         return state.leaveParticipant(offlineParticipant);
     }
     
@@ -1167,7 +1209,7 @@ public class GameManager implements Listener {
      * @param description a description of why the score changed
      * @return the new score of the participant
      */
-    public int addScore(OfflineParticipant participant, int score, @NotNull String description) {
+    public CompletableFuture<Integer> addScore(OfflineParticipant participant, int score, @NotNull String description) {
         return setScore(participant, participant.getScore() + score, description);
     }
     
@@ -1178,7 +1220,7 @@ public class GameManager implements Listener {
      * @param description a description of why the score changed
      * @return the new score of the team
      */
-    public int addScore(@NotNull Team team, int score, @NotNull String description) {
+    public CompletableFuture<Integer> addScore(@NotNull Team team, int score, @NotNull String description) {
         return setScore(team, team.getScore() + score, description);
     }
     
@@ -1187,9 +1229,9 @@ public class GameManager implements Listener {
      * @param participant the participant to set the score of
      * @param value the score to set the participant to
      * @param description a description of why the score changed
-     * @return the new score of the participant
+     * @return the new score of the participant in a future after database operations are complete
      */
-    public int setScore(@NotNull OfflineParticipant participant, int value, @NotNull String description) {
+    public CompletableFuture<Integer> setScore(@NotNull OfflineParticipant participant, int value, @NotNull String description) {
         int oldScore = participant.getScore();
         int score = Math.max(0, value);
         OfflineParticipant updated = new OfflineParticipant(participant, score);
@@ -1203,37 +1245,33 @@ public class GameManager implements Listener {
         } else {
             updatedList = Collections.emptyList();
         }
-        gameStateStorageUtil.updateScore(updated);
-        plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
-            try {
-                gameStateStorageUtil.persistScore(updated);
-                int actualDelta = score - oldScore;
-                logScoreEvents(List.of(
-                        ScoreEvent.builder()
-                                .sourceType(ScoreEvent.SourceType.ADMIN)
-                                .gameSessionId(null)
-                                .participantUUID(participant.getUniqueId().toString())
-                                .teamId(participant.getTeamId())
-                                .pointsBase(actualDelta)
-                                .description(description)
-                                .createdAt(new Date())
-                                .build(),
-                        ScoreEvent.builder()
-                                .sourceType(ScoreEvent.SourceType.ADMIN)
-                                .gameSessionId(null)
-                                .participantUUID(null)
-                                .teamId(participant.getTeamId())
-                                .pointsBase(-actualDelta)
-                                .description(String.format("%s (team adjustment)", description))
-                                .createdAt(new Date())
-                                .build()
-                ));
-            } catch (SQLException e) {
-                reportGameStateException("setting a participant's score", e);
-            }
-        });
+        gameStateStorageUtil.persistScore(updated);
         state.updateScoreVisuals(Collections.singletonList(teams.get(updated.getTeamId())), updatedList);
-        return updated.getScore();
+        int newScore = updated.getScore();
+        return CompletableFuture.runAsync(() -> {
+                    int actualDelta = score - oldScore;
+                    logScoreEvents(List.of(
+                            ScoreEvent.builder()
+                                    .sourceType(ScoreEvent.SourceType.ADMIN)
+                                    .gameSessionId(null)
+                                    .participantUUID(participant.getUniqueId().toString())
+                                    .teamId(participant.getTeamId())
+                                    .pointsBase(actualDelta)
+                                    .description(description)
+                                    .createdAt(new Date())
+                                    .build(),
+                            ScoreEvent.builder()
+                                    .sourceType(ScoreEvent.SourceType.ADMIN)
+                                    .gameSessionId(null)
+                                    .participantUUID(null)
+                                    .teamId(participant.getTeamId())
+                                    .pointsBase(-actualDelta)
+                                    .description(String.format("%s (team adjustment)", description))
+                                    .createdAt(new Date())
+                                    .build()
+                    ));
+                }, plugin.getDatabaseExecutor())
+                .thenApply(v -> newScore);
     }
     
     /**
@@ -1243,35 +1281,31 @@ public class GameManager implements Listener {
      * @param description a description of why the score changed
      * @return the new score of the team
      */
-    public int setScore(Team team, int value, @NotNull String description) {
+    public CompletableFuture<Integer> setScore(Team team, int value, @NotNull String description) {
         int oldScore = team.getScore();
         int score = Math.max(0, value);
         MCTTeam old = teams.get(team.getTeamId());
         if (old == null) {
-            return 0;
+            return CompletableFuture.completedFuture(0);
         }
         MCTTeam updated = new MCTTeam(old, score);
         teams.put(old.getTeamId(), updated);
-        gameStateStorageUtil.updateScore(updated);
-        plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
-            try {
-                gameStateStorageUtil.persistScore(updated);
-                int actualDelta = score - oldScore;
-                logScoreEvent(ScoreEvent.builder()
-                        .sourceType(ScoreEvent.SourceType.ADMIN)
-                        .gameSessionId(null)
-                        .participantUUID(null)
-                        .teamId(team.getTeamId())
-                        .pointsBase(actualDelta)
-                        .description(description)
-                        .createdAt(new Date())
-                        .build());
-            } catch (SQLException e) {
-                reportGameStateException("adding score to team", e);
-            }
-        });
+        gameStateStorageUtil.persistScore(updated);
         state.updateScoreVisuals(Collections.singletonList(updated), Collections.emptyList());
-        return updated.getScore();
+        int newScore = updated.getScore();
+        return CompletableFuture.runAsync(() -> {
+                    int actualDelta = score - oldScore;
+                    logScoreEvent(ScoreEvent.builder()
+                            .sourceType(ScoreEvent.SourceType.ADMIN)
+                            .gameSessionId(null)
+                            .participantUUID(null)
+                            .teamId(team.getTeamId())
+                            .pointsBase(actualDelta)
+                            .description(description)
+                            .createdAt(new Date())
+                            .build());
+                }, plugin.getDatabaseExecutor())
+                .thenApply(v -> newScore);
     }
     
     /**
@@ -1299,8 +1333,9 @@ public class GameManager implements Listener {
     /**
      * Set all the teams and players scores to the given score
      * @param value the score to set to. If the score is negative, the score will be set to 0.
+     * @return a future containing database operations
      */
-    public void setScoreAll(int value, @NotNull String description) {
+    public CompletableFuture<Void> setScoreAll(int value, @NotNull String description) {
         int score = Math.max(0, value);
         // this list is for passing info to the logScoreEvents call below, and nothing else
         Map<String, AllScoreEntity> teamDeltas = new HashMap<>(teams.size());
@@ -1332,7 +1367,8 @@ public class GameManager implements Listener {
         }
         actualDeltas.addAll(teamDeltas.values());
         gameStateStorageUtil.updateScores(teams.values(), allParticipants.values());
-        plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
+        state.updateScoreVisuals(teams.values(), onlineParticipants.values());
+        return CompletableFuture.runAsync(() -> {
             Date date = new Date();
             List<ScoreEvent> scoreEvents = actualDeltas.stream()
                     .map(actualDelta -> ScoreEvent.builder()
@@ -1351,8 +1387,7 @@ public class GameManager implements Listener {
             } catch (Exception e) {
                 reportGameStateException("setting all scores", e);
             }
-        });
-        state.updateScoreVisuals(teams.values(), onlineParticipants.values());
+        }, plugin.getDatabaseExecutor());
     }
     
     /**
@@ -1369,7 +1404,7 @@ public class GameManager implements Listener {
      * participant, they are removed from their team and added as an admin.
      * @param newAdmin The player to add
      */
-    public CommandResult addAdmin(Player newAdmin) {
+    public CompletableFuture<CommandResult> addAdmin(Player newAdmin) {
         return state.addAdmin(newAdmin);
     }
     
@@ -1379,7 +1414,7 @@ public class GameManager implements Listener {
      * @param adminName Something to use as the admin name for console output, even if it's just the UUID of the offline
      * player
      */
-    public @NotNull CommandResult removeAdmin(@NotNull OfflinePlayer offlineAdmin, @NotNull String adminName) {
+    public @NotNull CompletableFuture<CommandResult> removeAdmin(@NotNull OfflinePlayer offlineAdmin, @NotNull String adminName) {
         return state.removeAdmin(offlineAdmin, adminName);
     }
     
@@ -1388,13 +1423,9 @@ public class GameManager implements Listener {
      * @return a list of all the names of all the admins, online or not, or an empty list
      * if there are no admins or if there is an error connecting to the database
      */
-    public @NotNull List<String> getAllAdminNames() {
-        try {
-            return gameStateStorageUtil.getAllAdminNames().values().stream()
-                    .toList();
-        } catch (SQLException e) {
-            return Collections.emptyList();
-        }
+    public @NotNull CompletableFuture<List<String>> getAllAdminNames() {
+        return gameStateStorageUtil.getAllAdminNames()
+                .thenApply(map -> map.values().stream().toList());
     }
     
     public @Nullable OfflinePlayer getOfflineAdmin(@NotNull UUID uuid) {
@@ -1478,7 +1509,7 @@ public class GameManager implements Listener {
         return state.redoGame(gameSessionId);
     }
     
-    public CommandResult modifyMaxGames(int newMaxGames) {
+    public CompletableFuture<CommandResult> modifyMaxGames(int newMaxGames) {
         return state.modifyMaxGames(newMaxGames);
     }
     
@@ -1515,7 +1546,7 @@ public class GameManager implements Listener {
     }
     
     // Test methods
-    public void reportGameStateException(String attemptedOperation, Exception e) {
+    public void reportGameStateException(String attemptedOperation, Throwable e) {
         Main.logger().severe(String.format("error while %s. See console log for error message.", attemptedOperation));
         messageAdmins(Component.empty()
                 .append(Component.text("error while "))

--- a/src/main/java/org/braekpo1nt/mctmanager/games/gamemanager/MCTTeam.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/gamemanager/MCTTeam.java
@@ -142,7 +142,6 @@ public class MCTTeam extends TeamInfo implements AudienceDelegate {
      * using {@link #quitOnlineMember(UUID)}.
      * <br>
      * Warning, this should not be used inside of games, only the GameManager.
-     * TODO: prevent users from accidentally leaving players from teams outside the GameManager
      * @param uuid the UUID of the old member
      * @return true if the given UUID was previously a member of this team
      * (see {@link #isMember(UUID)}), false otherwise
@@ -160,7 +159,6 @@ public class MCTTeam extends TeamInfo implements AudienceDelegate {
      * Remove multiple old members of this team
      * <br>
      * Warning, this should not be used inside of games, only the GameManager.
-     * TODO: prevent users from accidentally leaving players from teams outside the GameManager
      * @param uuids the UUIDs of the members to remove from this team
      * @return true if any members were removed, false otherwise
      */

--- a/src/main/java/org/braekpo1nt/mctmanager/games/gamemanager/practice/PracticeManager.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/gamemanager/practice/PracticeManager.java
@@ -13,6 +13,7 @@ import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
+import org.braekpo1nt.mctmanager.Main;
 import org.braekpo1nt.mctmanager.commands.manager.commandresult.CommandResult;
 import org.braekpo1nt.mctmanager.games.gamemanager.GameInstanceId;
 import org.braekpo1nt.mctmanager.games.gamemanager.GameManager;
@@ -38,6 +39,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.logging.Level;
 
 public class PracticeManager {
     
@@ -119,8 +122,8 @@ public class PracticeManager {
                     .append(Component.text(" in "))
                     .append(Component.text(id.getTitle()))));
             main.addItem(new GuiItem(joinGame, event -> {
-                CommandResult commandResult = gameManager.joinParticipantToGame(id.getGameType(), id.getConfigFile(), participant.getUniqueId());
-                participant.sendMessage(commandResult.getMessageOrEmpty());
+                CompletableFuture<CommandResult> futureResult = gameManager.joinParticipantToGame(id.getGameType(), id.getConfigFile(), participant.getUniqueId());
+                CommandResult.showResult(participant, futureResult);
             }));
         }
         // Team Select
@@ -557,10 +560,14 @@ public class PracticeManager {
             }
         }
         Set<String> teamIds = invite.getConfirmedGuestIds();
-        CommandResult commandResult = gameManager.startGame(
-                teamIds, Collections.emptyList(),
-                invite.getId().getGameType(), invite.getId().getConfigFile());
-        initiatorAudience.sendMessage(commandResult.getMessageOrEmpty());
+        CompletableFuture<CommandResult> futureResult = gameManager.startGame(
+                        teamIds,
+                        Collections.emptyList(),
+                        invite.getId().getGameType(),
+                        invite.getId().getConfigFile()
+                )
+                .exceptionally(e -> CommandResult.throwable("start game", e));
+        CommandResult.showResult(initiatorAudience, futureResult);
     }
     
     private @NotNull ChestGui createTeamMenu(PracticeParticipant participant) {
@@ -573,10 +580,7 @@ public class PracticeManager {
                 ItemStack teamWool = new ItemStack(team.getColorAttributes().getWool());
                 teamWool.editMeta(meta -> meta.displayName(team.getFormattedDisplayName()));
                 teamSelect.addItem(new GuiItem(teamWool, event -> {
-                    Component message = joinTeam(event, team.getTeamId()).getMessage();
-                    if (message != null) {
-                        event.getWhoClicked().sendMessage(message);
-                    }
+                    CommandResult.showResult(event.getWhoClicked(), joinTeam(event, team.getTeamId()));
                 }));
             }
         }
@@ -593,10 +597,10 @@ public class PracticeManager {
         return gui;
     }
     
-    private CommandResult joinTeam(InventoryClickEvent event, String teamId) {
+    private CompletableFuture<CommandResult> joinTeam(InventoryClickEvent event, String teamId) {
         PracticeParticipant participant = participants.get(event.getWhoClicked().getUniqueId());
         if (participant == null) {
-            return CommandResult.failure("You are not a participant");
+            return CommandResult.failure("You are not a participant").asFuture();
         }
         return gameManager.joinOnlineParticipant(participant.getPlayer(), teamId);
     }

--- a/src/main/java/org/braekpo1nt/mctmanager/games/gamemanager/states/ContextReference.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/gamemanager/states/ContextReference.java
@@ -21,6 +21,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.Executor;
 
 /**
  * Used to pass info from {@link GameManager} to {@link GameManagerState}
@@ -41,6 +42,7 @@ public class ContextReference {
     private final @NotNull Map<UUID, GameInstanceId> adminEditors;
     private final @NotNull Main plugin;
     private final @NotNull GameStateStorageUtil gameStateStorageUtil;
+    private final @NotNull Executor mainThreadExecutor;
     private final @NotNull SidebarFactory sidebarFactory;
     private final @NotNull List<LeaderboardManager> leaderboardManagers;
     private final @NotNull Sidebar sidebar;

--- a/src/main/java/org/braekpo1nt/mctmanager/games/gamemanager/states/GameManagerState.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/gamemanager/states/GameManagerState.java
@@ -14,7 +14,6 @@ import org.braekpo1nt.mctmanager.commands.manager.commandresult.CompositeCommand
 import org.braekpo1nt.mctmanager.config.Config;
 import org.braekpo1nt.mctmanager.config.exceptions.ConfigException;
 import org.braekpo1nt.mctmanager.config.exceptions.ConfigIOException;
-import org.braekpo1nt.mctmanager.config.exceptions.ConfigInvalidException;
 import org.braekpo1nt.mctmanager.database.entities.EventInfo;
 import org.braekpo1nt.mctmanager.database.entities.GameSession;
 import org.braekpo1nt.mctmanager.games.game.capturetheflag.CaptureTheFlagGame;
@@ -106,6 +105,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
 import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
@@ -145,6 +147,7 @@ public abstract class GameManagerState {
      * an editor.
      */
     protected final Map<UUID, GameInstanceId> adminEditors;
+    private final @NotNull Executor mainThreadExecutor;
     @Setter
     protected @NotNull HubConfig config;
     
@@ -170,6 +173,7 @@ public abstract class GameManagerState {
         this.onlineParticipants = contextReference.getOnlineParticipants();
         this.onlineAdmins = contextReference.getOnlineAdmins();
         this.config = context.getConfig();
+        this.mainThreadExecutor = contextReference.getMainThreadExecutor();
     }
     
     /**
@@ -196,80 +200,58 @@ public abstract class GameManagerState {
         this.allParticipants.clear();
     }
     
-    protected abstract @NotNull CommandResult rebuildFromScores() throws SQLException;
+    protected abstract @NotNull CompletableFuture<CommandResult> rebuildFromScores();
     
-    public @NotNull CommandResult loadGameState() {
-        List<CommandResult> results = new ArrayList<>();
+    public @NotNull CompletableFuture<CommandResult> loadGameState() {
+        CompletableFuture<CommandResult> chain = CompletableFuture.completedFuture(CommandResult.success());
         if (!context.getActiveGameIds().isEmpty()) {
-            results.add(stopAllGames());
+            chain = chain.thenCompose(ignored -> stopAllGames());
         }
         if (editorIsRunning()) {
-            results.add(stopEditor());
+            chain = chain.thenApplyAsync(results -> results.and(stopEditor()), mainThreadExecutor);
         }
         // a given participant or admin may not be re-added when loading the new state
         for (Player admin : new ArrayList<>(onlineAdmins)) {
             onAdminQuit(admin);
         }
         for (MCTParticipant participant : new ArrayList<>(onlineParticipants.values())) {
-            onParticipantQuit(participant);
+            chain = chain.thenCompose(results -> {
+                CompletableFuture<Void> joinFuture = onParticipantQuit(participant);
+                return joinFuture.thenApply(v -> results);
+            });
         }
-        CommandResult rebuildResult = rebuildAndReload();
-        results.add(rebuildResult);
-        CommandResult loadResult = loadGameStateSync();
-        results.add(loadResult);
-        return new CompositeCommandResult(results);
+        return CommandResult.appendAsync(
+                        chain,
+                        this::rebuildAndReload,
+                        mainThreadExecutor
+                )
+                .thenComposeAsync(compositeResult -> {
+                    CompletableFuture<CommandResult> joinFuture = loadGameStateMainThread();
+                    return joinFuture.thenApply(loadResult -> loadResult.and(compositeResult));
+                }, mainThreadExecutor);
     }
-    // TODO: return this to async operation after 3/21/2026 event
-//        return CommandResult.async(
-//        plugin,
-//                Component.text("Loading game state..."),
-//        rebuildAndReload(),
-//                    this::loadGameStateSync
-//            );
-//    }
-//
-//    protected @NotNull CompletableFuture<CommandResult> rebuildAndReload() {
-//        return CompletableFuture.supplyAsync(() -> {
-//            List<CommandResult> results = new ArrayList<>();
-//            try {
-//                results.add(rebuildFromScores());
-//            } catch (SQLException e) {
-//                context.reportGameStateException("rebuilding from scores", e);
-//                results.add(CommandResult.sqlException("rebuilding from scores", e));
-//            }
-//            try {
-//                gameStateStorageUtil.loadGameState();
-//                results.add(CommandResult.success(Component.text("Loaded from database")));
-//            } catch (SQLException e) {
-//                context.reportGameStateException("loading game state", e);
-//                results.add(CommandResult.sqlException("loading game state", e));
-//            }
-//            return new CompositeCommandResult(results);
-//        });
-//    }
     
-    protected @NotNull CommandResult rebuildAndReload() {
-        List<CommandResult> results = new ArrayList<>();
-        try {
-            CommandResult rebuildResult = rebuildFromScores();
-            results.add(rebuildResult);
-        } catch (SQLException e) {
-            context.reportGameStateException("rebuilding from scores", e);
-            results.add(CommandResult.sqlException("rebuilding from scores", e));
-        }
-        try {
-            gameStateStorageUtil.loadGameState();
-            results.add(CommandResult.success(Component.text("Loaded from database")));
-        } catch (SQLException e) {
-            context.reportGameStateException("loading game state", e);
-            results.add(CommandResult.sqlException("loading game state", e));
-        }
-        return new CompositeCommandResult(results);
+    protected @NotNull CompletableFuture<CommandResult> rebuildAndReload() {
+        return rebuildFromScores()
+                .thenComposeAsync(result -> {
+                    try {
+                        CompletableFuture<Void> joinFuture = gameStateStorageUtil.loadGameState();
+                        return joinFuture.thenApply(v -> result);
+                    } catch (SQLException e) {
+                        throw new CompletionException(e);
+                    }
+                }, context.getMainThreadExecutor())
+                .exceptionally(e -> CommandResult.throwable("loading game state", e));
     }
     
     public abstract @NotNull String getSystemStateDescription();
     
-    protected @NotNull CommandResult loadGameStateSync() {
+    /**
+     * The part of the loading the game state action that should be run on the main
+     * Bukkit thread, because it impacts the world state
+     * @return a result detailing the success or failure of the action
+     */
+    protected @NotNull CompletableFuture<CommandResult> loadGameStateMainThread() {
         List<CommandResult> results = new ArrayList<>();
         try {
             this.config = new HubConfigController(plugin.getDataFolder()).getConfig();
@@ -324,6 +306,7 @@ public abstract class GameManagerState {
         // TabList stop
         
         // Log on all online admins and participants
+        CompletableFuture<Void> chain = CompletableFuture.completedFuture(null);
         for (Player player : onlinePlayers.values()) {
             if (context.isAdmin(player.getUniqueId())) {
                 onAdminJoin(player);
@@ -331,7 +314,7 @@ public abstract class GameManagerState {
             OfflineParticipant offlineParticipant = allParticipants.get(player.getUniqueId());
             if (offlineParticipant != null) {
                 MCTParticipant participant = new MCTParticipant(offlineParticipant, player);
-                onParticipantJoin(participant);
+                chain = chain.thenComposeAsync(v -> onParticipantJoin(participant), mainThreadExecutor);
             }
         }
         
@@ -341,7 +324,7 @@ public abstract class GameManagerState {
         // sidebar stop
         results.add(CommandResult.success(Component.text("Loaded gameState")));
         postLoadGameState();
-        return CompositeCommandResult.all(results);
+        return chain.thenApply(v -> CompositeCommandResult.all(results));
     }
     
     protected void postLoadGameState() {
@@ -369,9 +352,10 @@ public abstract class GameManagerState {
         updateSidebarTeamScores();
     }
     
-    public final void onParticipantJoin(@NotNull PlayerJoinEvent event, @NotNull MCTParticipant participant) {
-        onParticipantJoin(participant);
+    public final CompletableFuture<Void> onParticipantJoin(@NotNull PlayerJoinEvent event, @NotNull MCTParticipant participant) {
+        CompletableFuture<Void> joinFuture = onParticipantJoin(participant);
         event.joinMessage(GameManagerUtils.replaceWithDisplayName(participant, event.joinMessage()));
+        return joinFuture;
     }
     
     public void onNonJoin(@NotNull Player player) {
@@ -381,13 +365,15 @@ public abstract class GameManagerState {
     /**
      * Handles when a participant joins
      * @param participant the participant who joined
+     * @return any async work done
      */
-    public void onParticipantJoin(@NotNull MCTParticipant participant) {
+    public CompletableFuture<Void> onParticipantJoin(@NotNull MCTParticipant participant) {
         onlineParticipants.put(participant.getUniqueId(), participant);
         MCTTeam team = teams.get(participant.getTeamId());
         team.joinOnlineMember(participant);
         setupScoreboard(participant);
         participant.addPotionEffect(Main.NIGHT_VISION);
+        participant.setGameMode(GameMode.ADVENTURE);
         Component displayName = Component.text(participant.getName(), team.getColor());
         participant.getPlayer().displayName(displayName);
         participant.getPlayer().playerListName(displayName);
@@ -397,6 +383,7 @@ public abstract class GameManagerState {
         ColorMap.colorLeatherArmor(participant, team.getBukkitColor());
         leaderboardManagers.forEach(manager -> manager.showPlayer(participant.getPlayer()));
         updateScoreVisuals(Collections.singletonList(team), Collections.singletonList(participant));
+        return CompletableFuture.completedFuture(null);
     }
     
     /**
@@ -448,9 +435,9 @@ public abstract class GameManagerState {
         admin.playerListName(displayName);
     }
     
-    public final void onParticipantQuit(@NotNull PlayerQuitEvent event, @NotNull MCTParticipant participant) {
+    public final CompletableFuture<Void> onParticipantQuit(@NotNull PlayerQuitEvent event, @NotNull MCTParticipant participant) {
         event.quitMessage(GameManagerUtils.replaceWithDisplayName(participant, event.quitMessage()));
-        onParticipantQuit(participant);
+        return onParticipantQuit(participant);
     }
     
     /**
@@ -459,14 +446,17 @@ public abstract class GameManagerState {
      * (see {@link GameManager#onPlayerQuit(PlayerQuitEvent)}),
      * or when they are removed from the participants list
      * @param participant The participant who left the event
+     * @return database operations in alt thread future
      * @see GameManager#leaveParticipant(OfflineParticipant)
      */
-    public void onParticipantQuit(@NotNull MCTParticipant participant) {
+    public CompletableFuture<Void> onParticipantQuit(@NotNull MCTParticipant participant) {
         GameInstanceId id = participantGames.get(participant.getUniqueId());
+        CompletableFuture<Void> chain = CompletableFuture.completedFuture(null);
         if (id != null) {
             MCTGame activeGame = activeGames.get(id);
             if (activeGame != null) {
-                activeGame.onQuit(participant.getTeamId(), participant.getUniqueId());
+                CompletableFuture<Void> quitGameFuture = activeGame.onQuit(participant.getTeamId(), participant.getUniqueId());
+                chain = chain.thenCompose(v -> quitGameFuture);
             }
             onParticipantReturnToHub(participant);
             participant.teleport(config.getSpawn());
@@ -483,6 +473,7 @@ public abstract class GameManagerState {
         GameManagerUtils.deColorLeatherArmor(participant.getInventory());
         tabList.setParticipantGrey(participant.getParticipantID(), true);
         leaderboardManagers.forEach(manager -> manager.hidePlayer(participant.getPlayer()));
+        return chain;
     }
     // leave/join end
     
@@ -683,27 +674,30 @@ public abstract class GameManagerState {
     // ui end
     
     // game start
-    public CommandResult startGame(@NotNull Set<String> teamIds, @NotNull List<Player> gameAdmins, @NotNull GameType gameType, @NotNull String configFile) {
+    public CompletableFuture<CommandResult> startGame(@NotNull Set<String> teamIds, @NotNull List<Player> gameAdmins, @NotNull GameType gameType, @NotNull String configFile) {
         GameInstanceId gameInstanceId = new GameInstanceId(gameType, configFile);
         if (teamIds.isEmpty()) {
-            return CommandResult.failure("Can't start a game with no teams.");
+            return CommandResult.failure("Can't start a game with no teams.").asFuture();
         }
         
         if (activeGames.containsKey(gameInstanceId)) {
             return CommandResult.failure(Component.text("There is already a ")
                     .append(Component.text(gameInstanceId.getTitle()))
-                    .append(Component.text(" game running.")));
+                    .append(Component.text(" game running."))
+            ).asFuture();
         }
         
         if (context.editorIsRunning()) {
-            return CommandResult.failure(Component.text("There is an editor running. You must stop the editor before you start a game."));
+            return CommandResult.failure(Component.text("There is an editor running. You must stop the editor before you start a game.")
+            ).asFuture();
         }
         
         if (onlineParticipants.isEmpty()) {
             return CommandResult.failure(Component.text("There are no online participants. You can add participants using:\n")
                     .append(Component.text("/mct team join <team> <member>")
                             .decorate(TextDecoration.BOLD)
-                            .clickEvent(ClickEvent.suggestCommand("/mct team join "))));
+                            .clickEvent(ClickEvent.suggestCommand("/mct team join ")))
+            ).asFuture();
         }
         
         Set<MCTTeam> gameTeams = new HashSet<>();
@@ -714,7 +708,8 @@ public abstract class GameManagerState {
                 return CommandResult.failure(Component.empty()
                         .append(Component.text(teamId)
                                 .decorate(TextDecoration.BOLD))
-                        .append(Component.text(" is not a valid teamId")));
+                        .append(Component.text(" is not a valid teamId"))
+                ).asFuture();
             }
             Collection<MCTParticipant> onlineMembers = team.getOnlineMembers();
             for (MCTParticipant onlineMember : onlineMembers) {
@@ -722,7 +717,8 @@ public abstract class GameManagerState {
                     return CommandResult.failure(Component.empty()
                             .append(Component.text("Can't start a game with "))
                             .append(team.getFormattedDisplayName())
-                            .append(Component.text(" because one of its members is already in a game")));
+                            .append(Component.text(" because one of its members is already in a game"))
+                    ).asFuture();
                 }
             }
             if (!onlineMembers.isEmpty()) {
@@ -732,29 +728,30 @@ public abstract class GameManagerState {
         }
         // make sure the player and team count requirements are met
         if (gameTeams.isEmpty()) {
-            return CommandResult.failure("None of the specified teams are online");
+            return CommandResult.failure("None of the specified teams are online").asFuture();
         }
         switch (gameType) {
             case CAPTURE_THE_FLAG -> {
                 if (gameTeams.size() < 2) {
-                    return CommandResult.failure(Component.text("Capture the Flag needs at least 2 teams online to play.").color(NamedTextColor.RED));
+                    return CommandResult.failure(Component.text("Capture the Flag needs at least 2 teams online to play.").color(NamedTextColor.RED)
+                    ).asFuture();
                 }
             }
             case FINAL, COLOSSAL_COMBAT -> {
                 if (gameTeams.size() < 2) {
                     return CommandResult.failure(Component.empty()
                             .append(Component.text(gameType.getTitle()))
-                            .append(Component.text(" needs at least 2 teams online to play")));
+                            .append(Component.text(" needs at least 2 teams online to play"))
+                    ).asFuture();
                 }
             }
         }
         
-        instantiateGame(
+        return instantiateGame(
                 gameInstanceId,
                 new HashSet<>(gameTeams),
                 new HashSet<>(gameParticipants),
                 gameAdmins);
-        return CommandResult.success();
     }
     
     public CommandResult startEditor(@NotNull GameType gameType, @NotNull String configFile) {
@@ -843,7 +840,7 @@ public abstract class GameManagerState {
         updateSidebarTeamScores();
     }
     
-    public CommandResult stopGame(@NotNull GameType gameType, @Nullable String configFile) {
+    public CompletableFuture<CommandResult> stopGame(@NotNull GameType gameType, @Nullable String configFile) {
         GameInstanceId id;
         if (configFile == null) {
             List<GameInstanceId> activeIds = new ArrayList<>();
@@ -858,12 +855,14 @@ public abstract class GameManagerState {
                 return CommandResult.failure(Component.empty()
                         .append(Component.text("No "))
                         .append(Component.text(gameType.getTitle()))
-                        .append(Component.text(" game is active right now")));
+                        .append(Component.text(" game is active right now"))
+                ).asFuture();
             } else {
                 return CommandResult.failure(Component.empty()
                         .append(Component.text("More than one instance of "))
                         .append(Component.text(gameType.getTitle()))
-                        .append(Component.text(" is active. Please specify a config.")));
+                        .append(Component.text(" is active. Please specify a config."))
+                ).asFuture();
             }
         } else {
             id = new GameInstanceId(gameType, configFile);
@@ -874,30 +873,32 @@ public abstract class GameManagerState {
                     .append(Component.text("No instances of game "))
                     .append(Component.text(id.getTitle())
                             .decorate(TextDecoration.BOLD))
-                    .append(Component.text(" are active")));
+                    .append(Component.text(" are active"))
+            ).asFuture();
         }
-        game.stop();
-        return CommandResult.success(Component.empty()
-                .append(Component.text("Stopping "))
-                .append(Component.text(id.getTitle()))
-                .append(Component.text(" ("))
-                .append(Component.text(id.getConfigFile()))
-                .append(Component.text(")")));
+        return game.stop()
+                .thenApply(v -> CommandResult.success(Component.empty()
+                        .append(Component.text("Stopping "))
+                        .append(Component.text(id.getTitle()))
+                        .append(Component.text(" ("))
+                        .append(Component.text(id.getConfigFile()))
+                        .append(Component.text(")")))
+                );
     }
     
-    public CommandResult stopAllGames() {
+    public CompletableFuture<CommandResult> stopAllGames() {
         if (activeGames.isEmpty()) {
-            return CommandResult.success(Component.text("No games are running"));
+            return CommandResult.success(Component.text("No games are running")).asFuture();
         }
         List<MCTGame> gamesToCancel = new ArrayList<>(activeGames.values());
-        List<CommandResult> results = new ArrayList<>(activeGames.size());
+        CompletableFuture<CommandResult> chain = CompletableFuture.completedFuture(CommandResult.success());
         for (MCTGame game : gamesToCancel) {
-            game.stop();
-            results.add(CommandResult.success(Component.empty()
-                    .append(Component.text("Stopped "))
-                    .append(Component.text(game.getType().getTitle()))));
+            chain = game.stop()
+                    .thenApply(v -> CommandResult.success(Component.empty()
+                            .append(Component.text("Stopped "))
+                            .append(Component.text(game.getType().getTitle()))));
         }
-        return CompositeCommandResult.all(results);
+        return chain;
     }
     
     /**
@@ -909,11 +910,12 @@ public abstract class GameManagerState {
      * @param gameParticipants the UUIDs of the participants which are online and were in the finished
      * game. Must be UUIDs which are keys in {@link #onlineParticipants}.
      * @param gameAdmins the admins who were in the game
+     * @return a future containing database operations
      */
-    public void gameIsOver(int gameSessionId, @NotNull GameInstanceId id, Map<String, Integer> teamScores, Map<UUID, Integer> participantScores, @NotNull Collection<UUID> gameParticipants, @NotNull List<Player> gameAdmins) {
+    public CompletableFuture<Void> gameIsOver(int gameSessionId, @NotNull GameInstanceId id, Map<String, Integer> teamScores, Map<UUID, Integer> participantScores, @NotNull Collection<UUID> gameParticipants, @NotNull List<Player> gameAdmins) {
         MCTGame game = activeGames.remove(id);
         if (game == null) {
-            return;
+            return CompletableFuture.completedFuture(null);
         }
         for (UUID uuid : gameParticipants) {
             MCTParticipant participant = onlineParticipants.get(uuid);
@@ -927,16 +929,17 @@ public abstract class GameManagerState {
             admin.sendMessage(Component.text("Returning to hub"));
         }
         Date endDate = new Date();
-        plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
-            try {
-                context.getScoreService().setGameSessionEndDate(gameSessionId, endDate);
-            } catch (SQLException e) {
-                Main.logger().log(Level.SEVERE, "An error occurred saving end-game data to the database", e);
-                context.messageAdmins(Component.empty()
-                        .append(Component.text("An error occurred saving end-game data to te database. See console for details.")));
-            }
-        });
-        addScores(teamScores, participantScores, gameSessionId, id, endDate);
+        return addScores(teamScores, participantScores, id)
+                .thenComposeAsync(v -> CompletableFuture.runAsync(() -> {
+                    try {
+                        context.getScoreService().setGameSessionEndDate(gameSessionId, endDate);
+                    } catch (SQLException e) {
+                        Main.logger().log(Level.SEVERE, "An error occurred saving end-game data to the database", e);
+                        context.messageAdmins(Component.empty()
+                                .append(Component.text("An error occurred saving end-game data to te database. See console for details.")));
+                    }
+                }, plugin.getDatabaseExecutor()))
+                ;
     }
     
     /**
@@ -945,16 +948,13 @@ public abstract class GameManagerState {
      * If any invalid teamIds or UUIDs are used, there will be errors
      * @param newTeamScores map of teamId to score to add. Must be teamIds of real teams
      * @param newParticipantScores map of UUID to score to add. Must be UUIDs of real participants
-     * @param gameSessionId the id of the {@link GameSession} associated with this game
      * @param id the {@link GameInstanceId}
-     * @param endDate the date the game ended
+     * @return a future with the database operations
      */
-    protected void addScores(
+    protected CompletableFuture<Void> addScores(
             Map<String, Integer> newTeamScores,
             Map<UUID, Integer> newParticipantScores,
-            int gameSessionId,
-            @NotNull GameInstanceId id,
-            @NotNull Date endDate) {
+            @NotNull GameInstanceId id) {
         // some values might be from offline teams who have been removed, but still saved as QuitData
         Map<String, Integer> teamScores = newTeamScores.entrySet().stream()
                 .filter(e -> teams.containsKey(e.getKey()))
@@ -982,79 +982,21 @@ public abstract class GameManagerState {
         }
         if (plugin.isEnabled()) {
             gameStateStorageUtil.updateScores(teams.values(), allParticipants.values());
-            plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
-                try {
-                    gameStateStorageUtil.persistScores(teams.values(), allParticipants.values());
-                } catch (Exception e) {
-                    context.reportGameStateException("updating scores", e);
-                }
-            });
-        } else {
-            // TODO: this may not be needed if active_* tables are rebuilt on plugin start
+        }
+        // TODO: this may not be needed if active_* tables are rebuilt on plugin start
+        updateScoreVisuals(teams.values(), onlineParticipants.values());
+        displayStats(teamScores, participantScores, id);
+        return CompletableFuture.runAsync(() -> {
             try {
                 gameStateStorageUtil.persistScores(teams.values(), allParticipants.values());
             } catch (Exception e) {
                 context.reportGameStateException("updating scores", e);
             }
-        }
-        updateScoreVisuals(teams.values(), onlineParticipants.values());
-        displayStats(teamScores, participantScores, id);
+        }, plugin.getDatabaseExecutor());
     }
     
     @Nullable public String getEventId() {
         return null;
-    }
-    
-    /**
-     * @param gameInstanceId the {@link GameInstanceId} with the {@link GameType} to instantiate the {@link MCTGame} for
-     * and the config file to use
-     * @param newTeams the teams to send to the game
-     * @param newParticipants the participants to send to the game
-     * @param newAdmins the admins to send to the game
-     */
-    protected void instantiateGame(
-            @NotNull GameInstanceId gameInstanceId,
-            Collection<Team> newTeams,
-            Collection<Participant> newParticipants,
-            List<Player> newAdmins) throws ConfigIOException, ConfigInvalidException {
-        plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
-            try {
-                asyncInstantiateGame(gameInstanceId, newTeams, newParticipants, newAdmins);
-            } catch (Exception e) {
-                plugin.getServer().getScheduler().runTask(plugin, () -> {
-                    onGameInstantiationFailure(gameInstanceId, newParticipants, newAdmins, e);
-                });
-            }
-        });
-    }
-    
-    /**
-     * Called if there is an exception thrown while trying to instantiate a game.
-     * This is used because games are started asynchronously (so that reading config files
-     * and communicating with the database does not lag the server) and thus an error may occur
-     * asynchronously, and certain states need to react to this failure in different ways.
-     * @param gameInstanceId the {@link GameInstanceId} of the game which failed
-     * @param newParticipants the participants who were supposed to be sent to this game
-     * @param newAdmins the admins who were supposed to be sent to this game
-     * @param e the exception which occurred to cause the failure
-     */
-    protected void onGameInstantiationFailure(@NotNull GameInstanceId gameInstanceId, Collection<Participant> newParticipants, List<Player> newAdmins, Exception e) {
-        Main.logger().log(Level.SEVERE, String.format("Error starting game %s", gameInstanceId), e);
-        Audience.audience(
-                Audience.audience(newParticipants),
-                Audience.audience(context.getOnlineAdmins())
-        ).sendMessage(Component.text("Can't start ")
-                .append(Component.text(gameInstanceId.getGameType().name())
-                        .decorate(TextDecoration.BOLD))
-                .append(Component.text(" with config file "))
-                .append(Component.text(gameInstanceId.getConfigFile())
-                        .decorate(TextDecoration.BOLD))
-                .append(Component.text(". Error starting game. See console for details:\n"))
-                .append(Component.text(e.getMessage()))
-                .color(NamedTextColor.RED));
-        Audience.audience(newParticipants).sendMessage(Component.empty()
-                .append(Component.text("Contact the admins for support."))
-                .color(NamedTextColor.RED));
     }
     
     /**
@@ -1065,133 +1007,143 @@ public abstract class GameManagerState {
      * @param newTeams the teams to send to the game
      * @param newParticipants the participants to send to the game
      * @param newAdmins the admins to send to the game
-     * @throws SQLException if there is an error persisting the {@link GameSession}
+     * @return a future result of starting the game
      */
-    private void asyncInstantiateGame(
+    private CompletableFuture<CommandResult> instantiateGame(
             @NotNull GameInstanceId gameInstanceId,
             Collection<Team> newTeams,
             Collection<Participant> newParticipants,
-            List<Player> newAdmins) throws SQLException {
+            List<Player> newAdmins
+    ) {
         GameType gameType = gameInstanceId.getGameType();
         String configFile = gameInstanceId.getConfigFile();
+        
+        return CompletableFuture.supplyAsync(() -> {
+                    try {
+                        return context.getScoreService().createGameSession(GameSession.builder()
+                                .gameType(gameType)
+                                .eventId(getEventId())
+                                .configFile(configFile)
+                                .startTime(new Date())
+                                .mode(getMode())
+                                .multiplier(getMultiplier())
+                                .build());
+                    } catch (SQLException e) {
+                        throw new CompletionException("Unable to create gameSession in database", e);
+                    }
+                }, plugin.getDatabaseExecutor())
+                // intentionally not catching with exceptionally clause, so that callers can decide how to proceed
+                .thenApplyAsync(gameSession -> _instantiateGame(
+                        gameInstanceId,
+                        newTeams,
+                        newParticipants,
+                        newAdmins,
+                        gameSession,
+                        gameType,
+                        configFile
+                ), plugin.getMainThreadExecutor());
+    }
+    
+    private @NotNull CommandResult _instantiateGame(
+            @NotNull GameInstanceId gameInstanceId,
+            Collection<Team> newTeams,
+            Collection<Participant> newParticipants,
+            List<Player> newAdmins,
+            @NotNull GameSession gameSession,
+            GameType gameType,
+            String configFile
+    ) {
         Component title = createNewTitle(gameType.getTitle());
-        Config config;
-        switch (gameType) {
-            case SPLEEF -> {
-                config = new SpleefConfigController(plugin.getDataFolder(), gameType.getId()).getConfig(configFile);
-            }
-            case CLOCKWORK -> {
-                config = new ClockworkConfigController(plugin.getDataFolder(), gameType.getId()).getConfig(configFile);
-            }
-            case SURVIVAL_GAMES -> {
-                config = new SurvivalGamesConfigController(plugin.getDataFolder(), gameType.getId()).getConfig(configFile);
-            }
-            case FARM_RUSH -> {
-                config = new FarmRushConfigController(plugin.getDataFolder(), gameType.getId()).getConfig(configFile);
-            }
-            case FOOT_RACE -> {
-                config = new FootRaceConfigController(plugin.getDataFolder(), gameType.getId()).getConfig(configFile);
-            }
-            case PARKOUR_PATHWAY -> {
-                config = new ParkourPathwayConfigController(plugin.getDataFolder(), gameType.getId()).getConfig(configFile);
-            }
-            case CAPTURE_THE_FLAG -> {
-                config = new CaptureTheFlagConfigController(plugin.getDataFolder(), gameType.getId()).getConfig(configFile);
-            }
-            case EXAMPLE -> {
-                config = new ExampleConfigController(plugin.getDataFolder(), gameType.getId()).getConfig(configFile);
-            }
-            case FINAL -> {
-                config = new ColossalCombatConfigController(plugin.getDataFolder(), gameType.getId()).getConfig(configFile);
-            }
-            case COLOSSAL_COMBAT -> {
-                config = new FinalConfigController(plugin.getDataFolder(), gameType.getId()).getConfig(configFile);
-            }
-            default -> {
-                throw new IllegalArgumentException(String.format("Unsupported GameType %s", gameType));
-            }
+        Config config = switch (gameType) {
+            case SPLEEF -> new SpleefConfigController(plugin.getDataFolder(), gameType.getId()).getConfig(configFile);
+            case CLOCKWORK ->
+                    new ClockworkConfigController(plugin.getDataFolder(), gameType.getId()).getConfig(configFile);
+            case SURVIVAL_GAMES ->
+                    new SurvivalGamesConfigController(plugin.getDataFolder(), gameType.getId()).getConfig(configFile);
+            case FARM_RUSH ->
+                    new FarmRushConfigController(plugin.getDataFolder(), gameType.getId()).getConfig(configFile);
+            case FOOT_RACE ->
+                    new FootRaceConfigController(plugin.getDataFolder(), gameType.getId()).getConfig(configFile);
+            case PARKOUR_PATHWAY ->
+                    new ParkourPathwayConfigController(plugin.getDataFolder(), gameType.getId()).getConfig(configFile);
+            case CAPTURE_THE_FLAG ->
+                    new CaptureTheFlagConfigController(plugin.getDataFolder(), gameType.getId()).getConfig(configFile);
+            case EXAMPLE -> new ExampleConfigController(plugin.getDataFolder(), gameType.getId()).getConfig(configFile);
+            case FINAL ->
+                    new ColossalCombatConfigController(plugin.getDataFolder(), gameType.getId()).getConfig(configFile);
+            case COLOSSAL_COMBAT ->
+                    new FinalConfigController(plugin.getDataFolder(), gameType.getId()).getConfig(configFile);
+        };
+        for (Participant participant : newParticipants) {
+            onParticipantJoinGame(gameInstanceId, participant);
         }
-        
-        // TODO: should this make the game instantiation fail, or just report the error?
-        GameSession gameSession = context.getScoreService().createGameSession(GameSession.builder()
-                .gameType(gameType)
-                .eventId(getEventId())
-                .configFile(configFile)
-                .startTime(new Date())
-                .mode(getMode())
-                .multiplier(getMultiplier())
-                .build());
-        if (gameSession == null) {
-            throw new SQLException("An error occurred creating a GameSession object in the database");
+        for (Player admin : newAdmins) {
+            onAdminJoinGame(gameInstanceId, admin);
         }
-        
-        plugin.getServer().getScheduler().runTask(plugin, () -> {
+        try {
+            MCTGame game = switch (gameType) {
+                case SPLEEF -> {
+                    yield new SpleefGame(plugin, context, title, gameSession.getId(), (SpleefConfig) config, configFile, newTeams, newParticipants, newAdmins);
+                }
+                case CLOCKWORK -> {
+                    yield new ClockworkGame(plugin, context, title, gameSession.getId(), (ClockworkConfig) config, configFile, newTeams, newParticipants, newAdmins);
+                }
+                case SURVIVAL_GAMES -> {
+                    yield new SurvivalGamesGame(plugin, context, title, gameSession.getId(), (SurvivalGamesConfig) config, configFile, newTeams, newParticipants, newAdmins);
+                }
+                case FARM_RUSH -> {
+                    yield new FarmRushGame(plugin, context, title, gameSession.getId(), (FarmRushConfig) config, configFile, newTeams, newParticipants, newAdmins);
+                }
+                case FOOT_RACE -> {
+                    yield new FootRaceGame(plugin, context, title, gameSession.getId(), (FootRaceConfig) config, configFile, newTeams, newParticipants, newAdmins);
+                }
+                case PARKOUR_PATHWAY -> {
+                    yield new ParkourPathwayGame(plugin, context, title, gameSession.getId(), (ParkourPathwayConfig) config, configFile, newTeams, newParticipants, newAdmins);
+                }
+                case CAPTURE_THE_FLAG -> {
+                    yield new CaptureTheFlagGame(plugin, context, title, gameSession.getId(), (CaptureTheFlagConfig) config, configFile, newTeams, newParticipants, newAdmins);
+                }
+                case EXAMPLE -> {
+                    yield new ExampleGame(plugin, context, title, gameSession.getId(), (ExampleConfig) config, configFile, newTeams, newParticipants, newAdmins);
+                }
+                case FINAL -> {
+                    List<Team> sortedTeams = newTeams.stream()
+                            .sorted((t1, t2) -> {
+                                int scoreComparison = t2.getScore() - t1.getScore();
+                                if (scoreComparison != 0) {
+                                    return scoreComparison;
+                                }
+                                return t1.getDisplayName().compareToIgnoreCase(t2.getDisplayName());
+                            }).toList();
+                    yield new ColossalCombatGame(plugin, context, title, gameSession.getId(), (ColossalCombatConfig) config, configFile, sortedTeams.getFirst(), sortedTeams.get(1), sortedTeams, newParticipants, newAdmins);
+                }
+                case COLOSSAL_COMBAT -> {
+                    List<Team> sortedTeams = newTeams.stream()
+                            .sorted((t1, t2) -> {
+                                int scoreComparison = t2.getScore() - t1.getScore();
+                                if (scoreComparison != 0) {
+                                    return scoreComparison;
+                                }
+                                return t1.getDisplayName().compareToIgnoreCase(t2.getDisplayName());
+                            }).toList();
+                    yield new FinalGame(plugin, context, title, gameSession.getId(), (FinalConfig) config, configFile, sortedTeams.getFirst(), sortedTeams.get(1), sortedTeams, newParticipants, newAdmins);
+                }
+            };
+            activeGames.put(gameInstanceId, game);
+        } catch (Exception e) {
             for (Participant participant : newParticipants) {
-                onParticipantJoinGame(gameInstanceId, participant);
+                onParticipantReturnToHub(participant);
             }
             for (Player admin : newAdmins) {
-                onAdminJoinGame(gameInstanceId, admin);
+                onAdminReturnToHub(admin);
             }
-            try {
-                MCTGame game = switch (gameType) {
-                    case SPLEEF -> {
-                        yield new SpleefGame(plugin, context, title, gameSession.getId(), (SpleefConfig) config, configFile, newTeams, newParticipants, newAdmins);
-                    }
-                    case CLOCKWORK -> {
-                        yield new ClockworkGame(plugin, context, title, gameSession.getId(), (ClockworkConfig) config, configFile, newTeams, newParticipants, newAdmins);
-                    }
-                    case SURVIVAL_GAMES -> {
-                        yield new SurvivalGamesGame(plugin, context, title, gameSession.getId(), (SurvivalGamesConfig) config, configFile, newTeams, newParticipants, newAdmins);
-                    }
-                    case FARM_RUSH -> {
-                        yield new FarmRushGame(plugin, context, title, gameSession.getId(), (FarmRushConfig) config, configFile, newTeams, newParticipants, newAdmins);
-                    }
-                    case FOOT_RACE -> {
-                        yield new FootRaceGame(plugin, context, title, gameSession.getId(), (FootRaceConfig) config, configFile, newTeams, newParticipants, newAdmins);
-                    }
-                    case PARKOUR_PATHWAY -> {
-                        yield new ParkourPathwayGame(plugin, context, title, gameSession.getId(), (ParkourPathwayConfig) config, configFile, newTeams, newParticipants, newAdmins);
-                    }
-                    case CAPTURE_THE_FLAG -> {
-                        yield new CaptureTheFlagGame(plugin, context, title, gameSession.getId(), (CaptureTheFlagConfig) config, configFile, newTeams, newParticipants, newAdmins);
-                    }
-                    case EXAMPLE -> {
-                        yield new ExampleGame(plugin, context, title, gameSession.getId(), (ExampleConfig) config, configFile, newTeams, newParticipants, newAdmins);
-                    }
-                    case FINAL -> {
-                        List<Team> sortedTeams = newTeams.stream()
-                                .sorted((t1, t2) -> {
-                                    int scoreComparison = t2.getScore() - t1.getScore();
-                                    if (scoreComparison != 0) {
-                                        return scoreComparison;
-                                    }
-                                    return t1.getDisplayName().compareToIgnoreCase(t2.getDisplayName());
-                                }).toList();
-                        yield new ColossalCombatGame(plugin, context, title, gameSession.getId(), (ColossalCombatConfig) config, configFile, sortedTeams.getFirst(), sortedTeams.get(1), sortedTeams, newParticipants, newAdmins);
-                    }
-                    case COLOSSAL_COMBAT -> {
-                        List<Team> sortedTeams = newTeams.stream()
-                                .sorted((t1, t2) -> {
-                                    int scoreComparison = t2.getScore() - t1.getScore();
-                                    if (scoreComparison != 0) {
-                                        return scoreComparison;
-                                    }
-                                    return t1.getDisplayName().compareToIgnoreCase(t2.getDisplayName());
-                                }).toList();
-                        yield new FinalGame(plugin, context, title, gameSession.getId(), (FinalConfig) config, configFile, sortedTeams.getFirst(), sortedTeams.get(1), sortedTeams, newParticipants, newAdmins);
-                    }
-                };
-                activeGames.put(gameInstanceId, game);
-            } catch (Exception e) {
-                for (Participant participant : newParticipants) {
-                    onParticipantReturnToHub(participant);
-                }
-                for (Player admin : newAdmins) {
-                    onAdminReturnToHub(admin);
-                }
-                onGameInstantiationFailure(gameInstanceId, newParticipants, newAdmins, e);
-            }
-        });
+            Main.logger().log(Level.SEVERE, "Could not start game", e);
+            return CommandResult.failure("Could not start game, see console for details");
+        }
+        return CommandResult.success(Component.empty()
+                .append(Component.text("Started "))
+                .append(title)
+        );
     }
     
     /**
@@ -1306,12 +1258,12 @@ public abstract class GameManagerState {
     // commands end
     
     // event start
-    public CommandResult startEvent(@NotNull EventInfo eventInfo, int maxGames, int currentGameNumber) {
-        return CommandResult.failure("Can't start an event in this mode");
+    public CompletableFuture<CommandResult> startEvent(@NotNull EventInfo eventInfo, int maxGames, int currentGameNumber) {
+        return CommandResult.failure("Can't start an event in this mode").asFuture();
     }
     
-    public @NotNull CommandResult stopEvent() {
-        return CommandResult.failure("No event is running");
+    public @NotNull CompletableFuture<CommandResult> stopEvent() {
+        return CommandResult.failure("No event is running").asFuture();
     }
     
     public boolean eventIsActive() {
@@ -1339,8 +1291,8 @@ public abstract class GameManagerState {
         return CommandResult.failure("Can't redo games in this state");
     }
     
-    public CommandResult modifyMaxGames(int newMaxGames) {
-        return CommandResult.failure("No event is active");
+    public CompletableFuture<CommandResult> modifyMaxGames(int newMaxGames) {
+        return CommandResult.failure("No event is active").asFuture();
     }
     
     public CommandResult whitelist(boolean whitelist) {
@@ -1373,42 +1325,43 @@ public abstract class GameManagerState {
      * @param colorString the string representing the color
      * @return the newly created team, or null if the given team already exists or could not be created
      */
-    public Team addTeam(String teamId, String teamDisplayName, String colorString) {
+    public CompletableFuture<Team> addTeam(String teamId, String teamDisplayName, String colorString) {
         if (teams.containsKey(teamId)) {
             return null;
         }
-        int score;
-        try {
-            score = gameStateStorageUtil.addTeam(teamId, teamDisplayName, colorString);
-        } catch (ConfigIOException | SQLException e) {
-            context.reportGameStateException("adding a team", e);
-            score = 0;
-        }
-        
-        NamedTextColor color = ColorMap.getNamedTextColor(colorString);
-        ColorAttributes colorAttributes = ColorMap.getColorAttributes(colorString);
-        MCTTeam team = new MCTTeam(teamId, teamDisplayName, color, colorAttributes, score);
-        teams.put(teamId, team);
-        
-        org.bukkit.scoreboard.Team newTeam = mctScoreboard.registerNewTeam(teamId);
-        newTeam.displayName(Component.text(teamDisplayName));
-        newTeam.color(color);
-        tabList.addTeam(teamId, teamDisplayName, color);
-        updateScoreVisuals(Collections.singletonList(team), Collections.emptyList());
-        return team;
+        return gameStateStorageUtil.addTeam(teamId, teamDisplayName, colorString)
+                .thenApplyAsync(score -> {
+                    NamedTextColor color = ColorMap.getNamedTextColor(colorString);
+                    ColorAttributes colorAttributes = ColorMap.getColorAttributes(colorString);
+                    MCTTeam team = new MCTTeam(teamId, teamDisplayName, color, colorAttributes, score);
+                    teams.put(teamId, team);
+                    
+                    org.bukkit.scoreboard.Team newTeam = mctScoreboard.registerNewTeam(teamId);
+                    newTeam.displayName(Component.text(teamDisplayName));
+                    newTeam.color(color);
+                    tabList.addTeam(teamId, teamDisplayName, color);
+                    updateScoreVisuals(Collections.singletonList(team), Collections.emptyList());
+                    return (Team) team;
+                }, mainThreadExecutor)
+                .exceptionally(e -> {
+                    // this is unlikely to happen as a result of a sql error, some other error happened
+                    Main.logger().log(Level.SEVERE, "unable to persist team", e);
+                    return null;
+                })
+                ;
     }
     
     /**
      * Remove the given team from the game
      * @param teamId teamId of the team to remove
      */
-    public CommandResult removeTeam(String teamId) {
+    public CompletableFuture<CommandResult> removeTeam(String teamId) {
         MCTTeam team = teams.get(teamId);
         if (team == null) {
-            Main.logf("team is null %s", teamId);
             return CommandResult.failure(Component.text("Team ")
                     .append(Component.text(teamId))
-                    .append(Component.text(" does not exist.")));
+                    .append(Component.text(" does not exist."))
+            ).asFuture();
         }
         
         // leave all participants on team start
@@ -1419,8 +1372,9 @@ public abstract class GameManagerState {
                 .map(onlineParticipants::get)
                 .filter(Objects::nonNull)
                 .collect(Collectors.toSet());
+        CompletableFuture<Void> chain = CompletableFuture.completedFuture(null);
         for (MCTParticipant participant : onlineMembers) {
-            onParticipantQuit(participant);
+            chain = chain.thenCompose(ignore -> onParticipantQuit(participant));
             onlineParticipants.remove(participant.getUniqueId());
         }
         org.bukkit.scoreboard.Team scoreboardTeam = mctScoreboard.getTeam(teamId);
@@ -1457,17 +1411,19 @@ public abstract class GameManagerState {
             Main.logger().warning(String.format("mctScoreboard could not find team \"%s\" (removeTeam)", teamId));
         }
         
-        Main.logf("about to return remove team async result %s", teamId);
-        try {
-            Main.logf("actually removing the team in the async result %s", teamId);
-            gameStateStorageUtil.removeTeam(teamId);
-            results.add(CommandResult.success(Component.text("Removed team ")
-                    .append(team.getFormattedDisplayName())));
-        } catch (ConfigIOException | SQLException e) {
-            context.reportGameStateException("removing team", e);
-            results.add(CommandResult.failure(Component.text("error occurred removing team, see console for details.")));
-        }
-        return CompositeCommandResult.all(results);
+        return chain
+                .thenCompose(v -> gameStateStorageUtil.removeTeam(teamId))
+                .thenApply(v -> {
+                    results.add(CommandResult.success(Component.text("Removed team ")
+                            .append(team.getFormattedDisplayName())));
+                    return CompositeCommandResult.all(results);
+                })
+                .exceptionally(e -> {
+                    context.reportGameStateException("removing team", e);
+                    results.add(CommandResult.failure(Component.text("error occurred removing team, see console for details.")));
+                    return CompositeCommandResult.all(results);
+                });
+        
     }
     // team stop
     
@@ -1491,14 +1447,16 @@ public abstract class GameManagerState {
     }
     
     /**
-     * Joins the given player to the team with the given teamId. If the player was on a team already (not teamId) they
-     * will be removed from that team and added to the other team.
-     * Note, this will not join a player to a team if that player is an admin.
+     * Joins the given player to the given team.
+     * If the player was on a team already they
+     * will be removed from that team and added to the other team.<br>
+     * This is the variant for offline participants. If the player is online, you should use
+     * {@link #joinOnlineParticipantToTeam(Player, MCTTeam)}
      * @param uuid The uuid of the participant to join to the given team
      * @param ign The ign of the participant to join to the given team
      * @param team The internal teamId of the team to join the player to.
      */
-    public CommandResult joinParticipantToTeam(@NotNull UUID uuid, @NotNull String ign, @NotNull MCTTeam team) {
+    public CompletableFuture<CommandResult> joinOfflineParticipantToTeam(@NotNull UUID uuid, @NotNull String ign, @NotNull MCTTeam team) {
         // warn about UUID and IGN mismatches
         OfflineParticipant existingParticipant = allParticipants.get(uuid);
         if (existingParticipant != null) {
@@ -1507,7 +1465,7 @@ public abstract class GameManagerState {
                 // the name doesn't match
                 return CommandResult.failure(Component.empty()
                         .append(Component.text("The given IGN does not match the UUID in the game state"))
-                );
+                ).asFuture();
             }
             // the name matches, proceed
         } else {
@@ -1517,103 +1475,115 @@ public abstract class GameManagerState {
                 // someone with that IGN but a different UUID exists
                 return CommandResult.failure(Component.empty()
                         .append(Component.text("The given UUID does not match the IGN in the game state"))
-                );
+                ).asFuture();
             }
         }
+        return joinParticipantToTeam(
+                uuid,
+                ign,
+                team,
+                existingParticipant,
+                null
+        );
         
-        List<CommandResult> results = new ArrayList<>();
-        if (context.isAdmin(uuid)) {
-            results.add(removeAdmin(uuid, ign));
-        }
-        if (existingParticipant != null) {
-            if (existingParticipant.isOnTeam(team)) {
-                results.add(CommandResult.success(Component.empty()
-                        .append(existingParticipant.displayName())
-                        .append(Component.text(" is already a member of "))
-                        .append(team.getFormattedDisplayName())
-                        .append(Component.text(". Nothing happened."))));
-                return CompositeCommandResult.all(results);
-            }
-            results.add(leaveParticipant(existingParticipant));
-        }
-        
-        int score;
-        try {
-            score = gameStateStorageUtil.addNewPlayer(uuid, ign, team.getTeamId());
-        } catch (ConfigIOException | SQLException e) {
-            score = 0;
-            context.reportGameStateException("adding new player", e);
-            results.add(CommandResult.failure(Component.text("error occurred adding new player, see console for details.")));
-        }
-        Component participantDisplayName = GameManagerUtils.createDisplayName(ign, team.getColor());
-        OfflineParticipant offlineParticipant = new OfflineParticipant(uuid, ign, participantDisplayName, team.getTeamId(), score);
-        allParticipants.put(offlineParticipant.getUniqueId(), offlineParticipant);
-        team.joinMember(offlineParticipant.getUniqueId());
-        tabList.joinParticipant(
-                offlineParticipant.getParticipantID(),
-                offlineParticipant.getName(),
-                offlineParticipant.getTeamId(),
-                true);
-        
-        context.updateLeaderboards();
-        results.add(CommandResult.success(Component.text("Joined ")
-                .append(offlineParticipant.displayName())
-                .append(Component.text(" to "))
-                .append(team.getFormattedDisplayName())));
-        // TODO: this is identical to below method except for these lines
-        return CompositeCommandResult.all(results);
     }
     
-    public CommandResult joinParticipantToTeam(@NotNull Player player, @NotNull MCTTeam team) {
+    /**
+     * Joins the given player to the given team.
+     * If the player was on a team already they
+     * will be removed from that team and added to the other team.<br>
+     * This is the variant for online participants. If the player is not online, you should use
+     * {@link #joinOfflineParticipantToTeam(UUID, String, MCTTeam)}
+     * @param player The player to join to the given team
+     * @param team The internal teamId of the team to join the player to.
+     */
+    public CompletableFuture<CommandResult> joinOnlineParticipantToTeam(@NotNull Player player, @NotNull MCTTeam team) {
         UUID uuid = player.getUniqueId();
-        String ign = player.getName();
-        List<CommandResult> results = new ArrayList<>();
-        if (context.isAdmin(uuid)) {
-            results.add(removeAdmin(uuid, ign));
-        }
         OfflineParticipant existingParticipant = allParticipants.get(uuid);
+        return joinParticipantToTeam(
+                uuid,
+                player.getName(),
+                team,
+                existingParticipant,
+                player
+        );
+    }
+    
+    /**
+     * The shared functionality of both online and offline player join to team versions<br>
+     * {@link #joinOfflineParticipantToTeam(UUID, String, MCTTeam)}<br>
+     * {@link #joinOnlineParticipantToTeam(Player, MCTTeam)}<br>
+     * Joins the given player to the given team
+     * @param uuid the uuid of the player
+     * @param ign the ign of the player
+     * @param team the team to join them to
+     * @param existingParticipant the existing participant, if one exists
+     * @param player the player to join, if they are online
+     * @return a future containing the join operation and database operations with appropriate threads
+     */
+    protected CompletableFuture<CommandResult> joinParticipantToTeam(
+            @NotNull UUID uuid,
+            @NotNull String ign,
+            @NotNull MCTTeam team,
+            @Nullable OfflineParticipant existingParticipant,
+            @Nullable Player player
+    ) {
+        CompletableFuture<CommandResult> chain = CompletableFuture.completedFuture(CommandResult.success());
+        if (context.isAdmin(uuid)) {
+            chain = chain.thenComposeAsync(compositeResult -> {
+                CompletableFuture<CommandResult> joinFuture = removeAdmin(uuid, ign);
+                return joinFuture.thenApply(v -> compositeResult);
+            }, mainThreadExecutor);
+        }
         if (existingParticipant != null) {
             if (existingParticipant.isOnTeam(team)) {
-                results.add(CommandResult.success(Component.empty()
-                        .append(existingParticipant.displayName())
-                        .append(Component.text(" is already a member of "))
-                        .append(team.getFormattedDisplayName())
-                        .append(Component.text(". Nothing happened."))));
-                return CompositeCommandResult.all(results);
+                return chain.thenApply(result -> result
+                        .and(CommandResult.success(Component.empty()
+                                .append(existingParticipant.displayName())
+                                .append(Component.text(" is already a member of "))
+                                .append(team.getFormattedDisplayName())
+                                .append(Component.text(". Nothing happened.")))
+                        )
+                );
             }
-            results.add(leaveParticipant(existingParticipant));
+            chain = chain.thenComposeAsync(compositeResult -> {
+                CompletableFuture<CommandResult> joinFuture = leaveParticipant(existingParticipant);
+                return joinFuture.thenApply(compositeResult::and);
+            }, mainThreadExecutor);
         }
         
-        int score;
-        try {
-            score = gameStateStorageUtil.addNewPlayer(uuid, ign, team.getTeamId());
-        } catch (ConfigIOException | SQLException e) {
-            score = 0;
-            context.reportGameStateException("adding new player", e);
-            results.add(CommandResult.failure(Component.text("error occurred adding new player, see console for details.")));
-        }
-        Component participantDisplayName = GameManagerUtils.createDisplayName(ign, team.getColor());
-        OfflineParticipant offlineParticipant = new OfflineParticipant(uuid, ign, participantDisplayName, team.getTeamId(), score);
-        allParticipants.put(offlineParticipant.getUniqueId(), offlineParticipant);
-        team.joinMember(offlineParticipant.getUniqueId());
-        tabList.joinParticipant(
-                offlineParticipant.getParticipantID(),
-                offlineParticipant.getName(),
-                offlineParticipant.getTeamId(),
-                true);
-        
-        context.updateLeaderboards();
-        results.add(CommandResult.success(Component.text("Joined ")
-                .append(offlineParticipant.displayName())
-                .append(Component.text(" to "))
-                .append(team.getFormattedDisplayName())));
-        // TODO: this is identical to the above method except for this line
-        MCTParticipant participant = new MCTParticipant(offlineParticipant, player);
-        participant.sendMessage(Component.text("You've been joined to team ")
-                .append(team.getFormattedDisplayName()));
-        onParticipantJoin(participant);
-        
-        return CompositeCommandResult.all(results);
+        return chain.thenComposeAsync(compositeResult -> {
+            CompletableFuture<OfflineParticipant> subChain = gameStateStorageUtil.joinPlayer(uuid, ign, team.getTeamId())
+                    .thenApplyAsync(score -> {
+                        Component participantDisplayName = GameManagerUtils.createDisplayName(ign, team.getColor());
+                        OfflineParticipant offlineParticipant = new OfflineParticipant(uuid, ign, participantDisplayName, team.getTeamId(), score);
+                        allParticipants.put(offlineParticipant.getUniqueId(), offlineParticipant);
+                        team.joinMember(offlineParticipant.getUniqueId());
+                        tabList.joinParticipant(
+                                offlineParticipant.getParticipantID(),
+                                offlineParticipant.getName(),
+                                offlineParticipant.getTeamId(),
+                                true);
+                        
+                        context.updateLeaderboards();
+                        return offlineParticipant;
+                    }, mainThreadExecutor);
+            if (player != null) {
+                subChain = subChain.thenComposeAsync(offlineParticipant -> {
+                    MCTParticipant participant = new MCTParticipant(offlineParticipant, player);
+                    participant.sendMessage(Component.text("You've been joined to team ")
+                            .append(team.getFormattedDisplayName()));
+                    return onParticipantJoin(participant)
+                            .thenApply(v -> offlineParticipant);
+                }, mainThreadExecutor);
+            }
+            return subChain.thenApply(offlineParticipant -> compositeResult.and(CommandResult.success(Component.text("Joined ")
+                            .append(offlineParticipant.displayName())
+                            .append(Component.text(" to "))
+                            .append(team.getFormattedDisplayName()))))
+                    .exceptionally(e -> CommandResult.throwable("add a new player", e))
+                    ;
+        }, mainThreadExecutor);
     }
     
     /**
@@ -1621,42 +1591,46 @@ public abstract class GameManagerState {
      * If a game is running, and the player is online, removes that player from the game as well.
      * @param offlineParticipant The participant to remove from their team
      */
-    public CommandResult leaveParticipant(@NotNull OfflineParticipant offlineParticipant) {
+    public CompletableFuture<CommandResult> leaveParticipant(@NotNull OfflineParticipant offlineParticipant) {
         MCTTeam team = teams.get(offlineParticipant.getTeamId());
         MCTParticipant participant = onlineParticipants.get(offlineParticipant.getUniqueId());
+        CompletableFuture<Void> chain = CompletableFuture.completedFuture(null);
         if (participant != null) {
-            onParticipantQuit(participant);
-            participant.sendMessage(Component.text("You've been removed from ")
-                    .append(team.getFormattedDisplayName()));
-            onlineParticipants.remove(participant.getUniqueId());
+            chain = chain
+                    .thenCompose(v -> onParticipantQuit(participant))
+                    .thenRunAsync(() -> {
+                        participant.sendMessage(Component.text("You've been removed from ")
+                                .append(team.getFormattedDisplayName()));
+                        onlineParticipants.remove(participant.getUniqueId()); // TODO: is this redundant?
+                    }, mainThreadExecutor);
         }
-        team.leaveMember(offlineParticipant.getUniqueId());
-        allParticipants.remove(offlineParticipant.getUniqueId());
-        try {
-            gameStateStorageUtil.leavePlayer(offlineParticipant.getUniqueId());
-        } catch (ConfigIOException | SQLException e) {
-            context.reportGameStateException("leaving player", e);
-            return CommandResult.failure(Component.text("error occurred leaving player, see console for details."));
-        }
-        context.updateLeaderboards();
-        tabList.leaveParticipant(offlineParticipant.getParticipantID());
-        org.bukkit.scoreboard.Team scoreboardTeam = mctScoreboard.getTeam(offlineParticipant.getTeamId());
-        if (scoreboardTeam != null) {
-            if (offlineParticipant.getPlayer() != null) {
-                scoreboardTeam.removePlayer(offlineParticipant.getPlayer());
-            }
-        } else {
-            Main.logger().warning(String.format("mctScoreboard could not find team \"%s\" (leaveParticipant)", offlineParticipant.getTeamId()));
-        }
-        return CommandResult.success(Component.text("Removed ")
-                .append(offlineParticipant.displayName())
-                .append(Component.text(" from team "))
-                .append(team.getFormattedDisplayName()));
+        return chain.thenRunAsync(() -> {
+                    team.leaveMember(offlineParticipant.getUniqueId());
+                    allParticipants.remove(offlineParticipant.getUniqueId());
+                }, mainThreadExecutor)
+                .thenCompose(v -> gameStateStorageUtil.leavePlayer(offlineParticipant.getUniqueId()))
+                .thenApplyAsync(v -> {
+                    context.updateLeaderboards();
+                    tabList.leaveParticipant(offlineParticipant.getParticipantID());
+                    org.bukkit.scoreboard.Team scoreboardTeam = mctScoreboard.getTeam(offlineParticipant.getTeamId());
+                    if (scoreboardTeam != null) {
+                        if (offlineParticipant.getPlayer() != null) {
+                            scoreboardTeam.removePlayer(offlineParticipant.getPlayer());
+                        }
+                    } else {
+                        Main.logger().warning(String.format("mctScoreboard could not find team \"%s\" (leaveParticipant)", offlineParticipant.getTeamId()));
+                    }
+                    return CommandResult.success(Component.text("Removed ")
+                            .append(offlineParticipant.displayName())
+                            .append(Component.text(" from team "))
+                            .append(team.getFormattedDisplayName()));
+                }, mainThreadExecutor)
+                .exceptionally(e -> CommandResult.throwable("leave player", e));
     }
     
-    public CommandResult joinParticipantToGame(@NotNull GameType gameType, @Nullable String configFile, @NotNull MCTParticipant participant) {
+    public CompletableFuture<CommandResult> joinParticipantToGame(@NotNull GameType gameType, @Nullable String configFile, @NotNull MCTParticipant participant) {
         if (isParticipantInGame(participant)) {
-            return CommandResult.failure(Component.text("Already in a game"));
+            return CommandResult.failure(Component.text("Already in a game")).asFuture();
         }
         GameInstanceId id;
         if (configFile == null) {
@@ -1672,12 +1646,14 @@ public abstract class GameManagerState {
                 return CommandResult.failure(Component.empty()
                         .append(Component.text("No "))
                         .append(Component.text(gameType.getTitle()))
-                        .append(Component.text(" game is active right now")));
+                        .append(Component.text(" game is active right now"))
+                ).asFuture();
             } else {
                 return CommandResult.failure(Component.empty()
                         .append(Component.text("More than one instance of "))
                         .append(Component.text(gameType.getTitle()))
-                        .append(Component.text(" is active. Please specify a config.")));
+                        .append(Component.text(" is active. Please specify a config."))
+                ).asFuture();
             }
         } else {
             id = new GameInstanceId(gameType, configFile);
@@ -1687,7 +1663,8 @@ public abstract class GameManagerState {
             return CommandResult.failure(Component.empty()
                     .append(Component.text("No "))
                     .append(Component.text(id.getTitle()))
-                    .append(Component.text(" game is active right now")));
+                    .append(Component.text(" game is active right now"))
+            ).asFuture();
         }
         @Nullable GameInstanceId teamGameId = context.getTeamActiveGame(participant.getTeamId());
         MCTTeam team = teams.get(participant.getTeamId());
@@ -1698,13 +1675,15 @@ public abstract class GameManagerState {
                     .append(Component.text(" because "))
                     .append(team.getFormattedDisplayName())
                     .append(Component.text(" is in "))
-                    .append(Component.text(teamGameId.getTitle())));
+                    .append(Component.text(teamGameId.getTitle()))
+            ).asFuture();
         }
         onParticipantJoinGame(id, participant);
-        activeGame.onJoin(team, participant);
-        return CommandResult.success(Component.empty()
-                .append(Component.text("Joining "))
-                .append(Component.text(id.getTitle())));
+        return activeGame.onJoin(team, participant)
+                .thenApply(v -> CommandResult.success(Component.empty()
+                        .append(Component.text("Joining "))
+                        .append(Component.text(id.getTitle()))))
+                ;
     }
     
     public @Nullable List<String> tabCompleteActiveGames(@NotNull String[] args) {
@@ -1768,26 +1747,27 @@ public abstract class GameManagerState {
                 .append(Component.text(id.getTitle())));
     }
     
-    public CommandResult returnParticipantToHub(@NotNull MCTParticipant participant) {
+    public CompletableFuture<CommandResult> returnParticipantToHub(@NotNull MCTParticipant participant) {
         return returnParticipantToHub(participant, config.getSpawn());
     }
     
-    protected CommandResult returnParticipantToHub(@NotNull MCTParticipant participant, @NotNull Location spawn) {
+    protected CompletableFuture<CommandResult> returnParticipantToHub(@NotNull MCTParticipant participant, @NotNull Location spawn) {
         GameInstanceId id = participantGames.remove(participant.getUniqueId());
         if (id == null) {
             participant.teleport(spawn);
-            return CommandResult.success(Component.text("Returning to hub"));
+            return CommandResult.success(Component.text("Returning to hub")).asFuture();
         }
         MCTGame activeGame = activeGames.get(id);
         if (activeGame == null) {
             // this should not happen
             participant.teleport(spawn);
-            return CommandResult.success(Component.text("Returning to hub"));
+            return CommandResult.success(Component.text("Returning to hub")).asFuture();
         }
-        activeGame.onQuit(participant.getTeamId(), participant.getUniqueId());
+        CompletableFuture<Void> quitFuture = activeGame.onQuit(participant.getTeamId(), participant.getUniqueId());
         onParticipantReturnToHub(participant);
         participant.teleport(spawn);
-        return CommandResult.success(Component.text("Quitting current game. Returning to hub."));
+        return quitFuture.thenApply(v ->
+                CommandResult.success(Component.text("Quitting current game. Returning to hub.")));
     }
     
     public CommandResult returnAdminToHub(@NotNull Player admin) {
@@ -1820,82 +1800,88 @@ public abstract class GameManagerState {
      * participant, they are removed from their team and added as an admin.
      * @param newAdmin The player to add
      */
-    public CommandResult addAdmin(Player newAdmin) {
+    public CompletableFuture<CommandResult> addAdmin(Player newAdmin) {
         UUID uniqueId = newAdmin.getUniqueId();
         if (gameStateStorageUtil.isAdmin(uniqueId)) {
             return CommandResult.failure(Component.empty()
                     .append(Component.text(newAdmin.getName())
                             .decorate(TextDecoration.BOLD))
-                    .append(Component.text(" is already an admin. Nothing happened.")));
+                    .append(Component.text(" is already an admin. Nothing happened."))
+            ).asFuture();
         }
-        List<CommandResult> results = new ArrayList<>();
+        CompletableFuture<CommandResult> chain = CompletableFuture.completedFuture(CommandResult.success());
         OfflineParticipant offlineParticipant = allParticipants.get(uniqueId);
         if (offlineParticipant != null) {
-            results.add(leaveParticipant(offlineParticipant));
+            chain = chain.thenComposeAsync(compositeResult -> {
+                CompletableFuture<CommandResult> joinFuture = leaveParticipant(offlineParticipant);
+                return joinFuture.thenApply(compositeResult::and);
+            }, mainThreadExecutor);
         }
-        try {
-            gameStateStorageUtil.addAdmin(uniqueId);
-        } catch (ConfigIOException | SQLException e) {
-            context.reportGameStateException("adding new admin", e);
-            results.add(CommandResult.failure(Component.text("error occurred adding new admin, see console for details.")));
-            return CompositeCommandResult.all(results);
-        }
-        
-        org.bukkit.scoreboard.Team adminTeam = mctScoreboard.getTeam(GameManager.ADMIN_TEAM);
-        if (adminTeam != null) {
-            adminTeam.addPlayer(newAdmin);
-        } else {
-            Main.logger().warning(String.format("mctScoreboard could not find team \"%s\" (addAdmin)", GameManager.ADMIN_TEAM));
-            ;
-        }
-        if (newAdmin.isOnline()) {
-            newAdmin.sendMessage(Component.text("You were added as an admin"));
-            onAdminJoin(newAdmin);
-        }
-        
-        results.add(CommandResult.success(Component.empty()
-                .append(Component.text("Added "))
-                .append(Component.text(newAdmin.getName())
-                        .decorate(TextDecoration.BOLD))
-                .append(Component.text(" as an admin"))));
-        return CompositeCommandResult.all(results);
+        return chain.thenApplyAsync(compositeResult -> {
+            try {
+                gameStateStorageUtil.addAdmin(uniqueId);
+            } catch (ConfigIOException | SQLException e) {
+                context.reportGameStateException("adding new admin", e);
+                return compositeResult.and(CommandResult.failure(
+                        Component.text("error occurred adding new admin, see console for details.")));
+            }
+            
+            org.bukkit.scoreboard.Team adminTeam = mctScoreboard.getTeam(GameManager.ADMIN_TEAM);
+            if (adminTeam != null) {
+                adminTeam.addPlayer(newAdmin);
+            } else {
+                Main.logger().warning(String.format("mctScoreboard could not find team \"%s\" (addAdmin)", GameManager.ADMIN_TEAM));
+                ;
+            }
+            if (newAdmin.isOnline()) {
+                newAdmin.sendMessage(Component.text("You were added as an admin"));
+                onAdminJoin(newAdmin);
+            }
+            
+            return compositeResult.and(CommandResult.success(Component.empty()
+                    .append(Component.text("Added "))
+                    .append(Component.text(newAdmin.getName())
+                            .decorate(TextDecoration.BOLD))
+                    .append(Component.text(" as an admin"))));
+        }, mainThreadExecutor);
     }
     
-    public @NotNull CommandResult removeAdmin(@NotNull UUID uuid, @NotNull String ign) {
+    public @NotNull CompletableFuture<CommandResult> removeAdmin(@NotNull UUID uuid, @NotNull String ign) {
+        // TODO: there are two removeAdmin methods, use only one
         if (!context.isAdmin(uuid)) {
             return CommandResult.failure(Component.empty()
                     .append(Component.text(ign)
                             .decorate(TextDecoration.BOLD))
-                    .append(Component.text(" is not an admin. Nothing happened.")));
+                    .append(Component.text(" is not an admin. Nothing happened."))
+            ).asFuture();
         }
         context.getOnlineAdmins().stream()
                 .filter(admin -> admin.getUniqueId().equals(uuid))
                 .findFirst().ifPresent(this::onAdminQuit);
-        try {
-            gameStateStorageUtil.removeAdmin(uuid);
-        } catch (ConfigIOException | SQLException e) {
-            context.reportGameStateException("removing admin", e);
-            return CommandResult.failure(Component.text("error occurred removing admin, see console for details."));
-        }
+        return gameStateStorageUtil.removeAdmin(uuid)
+                .thenApplyAsync(v -> CommandResult.success(Component.empty()
+                        .append(Component.text(ign)
+                                .decorate(TextDecoration.BOLD))
+                        .append(Component.text(" is no longer an admin"))), mainThreadExecutor)
+                .exceptionally(e -> CommandResult.throwable("remove an admin", e))
+                ;
         
         // TODO: remove them from the scoreboard in a different context
         
-        return CommandResult.success(Component.empty()
-                .append(Component.text(ign)
-                        .decorate(TextDecoration.BOLD))
-                .append(Component.text(" is no longer an admin")));
     }
     
     /**
      * Removes the given player from the admins
      * @param offlineAdmin The admin to remove
      */
-    public @NotNull CommandResult removeAdmin(@NotNull OfflinePlayer offlineAdmin, @NotNull String adminName) {
+    public @NotNull CompletableFuture<CommandResult> removeAdmin(@NotNull OfflinePlayer offlineAdmin, @NotNull String adminName) {
+        // TODO: there are two removeAdmin methods, use only one
         if (!context.isAdmin(offlineAdmin.getUniqueId())) {
             return CommandResult.failure(Component.empty()
                     .append(Component.text(adminName)
                             .decorate(TextDecoration.BOLD))
-                    .append(Component.text(" is not an admin. Nothing happened.")));
+                    .append(Component.text(" is not an admin. Nothing happened."))
+            ).asFuture();
         }
         if (offlineAdmin.isOnline()) {
             Player onlineAdmin = offlineAdmin.getPlayer();
@@ -1905,24 +1891,21 @@ public abstract class GameManagerState {
             }
         }
         UUID adminUniqueId = offlineAdmin.getUniqueId();
-        try {
-            gameStateStorageUtil.removeAdmin(adminUniqueId);
-        } catch (ConfigIOException | SQLException e) {
-            context.reportGameStateException("removing admin", e);
-            return CommandResult.failure(Component.text("error occurred removing admin, see console for details."));
-        }
-        
-        org.bukkit.scoreboard.Team adminTeam = mctScoreboard.getTeam(GameManager.ADMIN_TEAM);
-        if (adminTeam != null) {
-            adminTeam.removePlayer(offlineAdmin);
-        } else {
-            Main.logger().warning(String.format("mctScoreboard could not find team \"%s\" (addAdmin)", GameManager.ADMIN_TEAM));
-        }
-        
-        return CommandResult.success(Component.empty()
-                .append(Component.text(adminName)
-                        .decorate(TextDecoration.BOLD))
-                .append(Component.text(" is no longer an admin")));
+        return gameStateStorageUtil.removeAdmin(adminUniqueId)
+                .thenApplyAsync(v -> {
+                    org.bukkit.scoreboard.Team adminTeam = mctScoreboard.getTeam(GameManager.ADMIN_TEAM);
+                    if (adminTeam != null) {
+                        adminTeam.removePlayer(offlineAdmin);
+                    } else {
+                        Main.logger().warning(String.format("mctScoreboard could not find team \"%s\" (addAdmin)", GameManager.ADMIN_TEAM));
+                    }
+                    
+                    return CommandResult.success(Component.empty()
+                            .append(Component.text(adminName)
+                                    .decorate(TextDecoration.BOLD))
+                            .append(Component.text(" is no longer an admin")));
+                }, mainThreadExecutor)
+                .exceptionally(e -> CommandResult.throwable("remove an admin", e));
     }
     
     public void onAdminDamage(@NotNull EntityDamageEvent event, @NotNull Player admin) {

--- a/src/main/java/org/braekpo1nt/mctmanager/games/gamemanager/states/MaintenanceState.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/gamemanager/states/MaintenanceState.java
@@ -15,7 +15,7 @@ import org.braekpo1nt.mctmanager.ui.sidebar.KeyLine;
 import org.braekpo1nt.mctmanager.ui.sidebar.Sidebar;
 import org.jetbrains.annotations.NotNull;
 
-import java.sql.SQLException;
+import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 
 public class MaintenanceState extends GameManagerState {
@@ -30,8 +30,9 @@ public class MaintenanceState extends GameManagerState {
     public void enter() {
         setupSidebar();
         contextReference.getGameStateStorageUtil().maintenanceMode();
-        CommandResult result = context.loadGameState();
-        CommandResult.showResult(contextReference.getPlugin().getServer().getConsoleSender(), result);
+        CompletableFuture<CommandResult> futureResult = context.loadGameState();
+        CommandResult.showResult(contextReference.getPlugin().getServer().getConsoleSender(), futureResult
+        );
     }
     
     @Override
@@ -81,7 +82,6 @@ public class MaintenanceState extends GameManagerState {
                 return CommandResult.success(Component.text("Switched to practice mode"));
             }
             case EVENT -> {
-                // TODO: use the active event from SystemState
                 return CommandResult.success(Component.empty()
                         .append(Component.text("At this time, you must switch to event mode using the \"/mct event start\" command"))
                 );
@@ -97,13 +97,11 @@ public class MaintenanceState extends GameManagerState {
     }
     
     @Override
-    protected @NotNull CommandResult rebuildFromScores() throws SQLException {
-        try {
-            context.getGameStateService().rebuildMaintenanceMode();
-            return CommandResult.success(Component.text("Rebuilt game state from maintenance mode"));
-        } catch (SQLException e) {
-            throw new SQLException("Unable to rebuild maintenance mode", e);
-        }
+    protected @NotNull CompletableFuture<CommandResult> rebuildFromScores() {
+        return context.getGameStateService().rebuildMaintenanceMode()
+                .thenApply(v -> CommandResult.success(Component.text("Rebuilt game state from maintenance mode")))
+                .exceptionally(e -> CommandResult.throwable("rebuild the maintenance game state", e))
+                ;
     }
     
     // team/participants management start
@@ -115,15 +113,16 @@ public class MaintenanceState extends GameManagerState {
     }
     
     @Override
-    public CommandResult startEvent(@NotNull EventInfo eventInfo, int maxGames, int currentGameNumber) {
+    public CompletableFuture<CommandResult> startEvent(@NotNull EventInfo eventInfo, int maxGames, int currentGameNumber) {
         try {
             EventConfig eventConfig = new EventConfigController(plugin.getDataFolder()).getConfig();
             context.setState(new ReadyUpState(context, contextReference, eventInfo, eventConfig, maxGames, currentGameNumber));
-            return CommandResult.success(Component.text("Switched to event mode"));
+            return CommandResult.success(Component.text("Switched to event mode")).asFuture();
         } catch (ConfigException e) {
             Main.logger().log(Level.SEVERE, e.getMessage(), e);
             return CommandResult.failure(Component.text("Can't switch to event mode. Error loading config file. See console for details:\n")
-                    .append(Component.text(e.getMessage())));
+                    .append(Component.text(e.getMessage()))
+            ).asFuture();
         }
     }
 }

--- a/src/main/java/org/braekpo1nt/mctmanager/games/gamemanager/states/PracticeState.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/gamemanager/states/PracticeState.java
@@ -16,9 +16,6 @@ import org.braekpo1nt.mctmanager.games.gamemanager.event.config.EventConfig;
 import org.braekpo1nt.mctmanager.games.gamemanager.event.config.EventConfigController;
 import org.braekpo1nt.mctmanager.games.gamemanager.practice.PracticeManager;
 import org.braekpo1nt.mctmanager.games.gamemanager.states.event.ReadyUpState;
-import org.braekpo1nt.mctmanager.games.gamestate.preset.PresetConfig;
-import org.braekpo1nt.mctmanager.games.gamestate.preset.PresetStorageUtil;
-import org.braekpo1nt.mctmanager.games.utils.GameManagerUtils;
 import org.braekpo1nt.mctmanager.participant.Participant;
 import org.braekpo1nt.mctmanager.participant.Team;
 import org.braekpo1nt.mctmanager.ui.sidebar.KeyLine;
@@ -29,16 +26,11 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.io.File;
-import java.sql.SQLException;
-import java.util.Date;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
-import java.util.stream.Collectors;
 
 public class PracticeState extends GameManagerState {
     
@@ -46,6 +38,7 @@ public class PracticeState extends GameManagerState {
     
     public PracticeState(@NotNull GameManager context, @NotNull ContextReference contextReference) {
         super(context, contextReference);
+        // TODO: since enter() loads a new game state, assigning any participants to this at this time is redundant because they are instantly removed and re-added
         this.practiceManager = new PracticeManager(
                 context,
                 config.getPractice(),
@@ -59,21 +52,8 @@ public class PracticeState extends GameManagerState {
     public void enter() {
         setupSidebar();
         contextReference.getGameStateStorageUtil().practiceMode();
-        // TODO: remove this
-        PresetConfig presetConfig = config.getPractice().getPreset();
-        if (presetConfig != null) {
-            CommandResult commandResult = GameManagerUtils.applyPreset(
-                    plugin,
-                    context,
-                    new PresetStorageUtil(plugin.getDataFolder()),
-                    new File(new File(plugin.getDataFolder(), "preset"), presetConfig.getFile()),
-                    plugin.getServer().getConsoleSender(),
-                    presetConfig.toOpts()
-            );
-            context.messageAdmins(commandResult.getMessageOrEmpty());
-        }
-        CommandResult result = context.loadGameState();
-        CommandResult.showResult(contextReference.getPlugin().getServer().getConsoleSender(), result);
+        CompletableFuture<CommandResult> futureResult = context.loadGameState();
+        CommandResult.showResult(contextReference.getPlugin().getServer().getConsoleSender(), futureResult);
     }
     
     @Override
@@ -87,13 +67,11 @@ public class PracticeState extends GameManagerState {
     }
     
     @Override
-    protected @NotNull CommandResult rebuildFromScores() throws SQLException {
-        try {
-            context.getGameStateService().rebuildPracticeMode();
-            return CommandResult.success(Component.text("Rebuilt game state from practice mode"));
-        } catch (SQLException e) {
-            throw new SQLException("Unable to rebuild practice mode", e);
-        }
+    protected @NotNull CompletableFuture<CommandResult> rebuildFromScores() {
+        return context.getGameStateService().rebuildPracticeMode()
+                .thenApply(v -> CommandResult.success(Component.text("Rebuilt game state from practice mode")))
+                .exceptionally(e -> CommandResult.throwable("rebuild the practice game state", e))
+                ;
     }
     
     @Override
@@ -150,7 +128,6 @@ public class PracticeState extends GameManagerState {
             }
             case EVENT -> {
 //                practiceManager.cleanup();
-                // TODO: use the active event from SystemState
                 return CommandResult.success(Component.empty()
                         .append(Component.text("At this time, you must switch to event mode using the \"/mct event start\" command"))
                 );
@@ -171,22 +148,23 @@ public class PracticeState extends GameManagerState {
     }
     
     @Override
-    public CommandResult startGame(@NotNull Set<String> teamIds, @NotNull List<Player> gameAdmins, @NotNull GameType gameType, @NotNull String configFile) {
+    public CompletableFuture<CommandResult> startGame(@NotNull Set<String> teamIds, @NotNull List<Player> gameAdmins, @NotNull GameType gameType, @NotNull String configFile) {
         if (gameType == GameType.FARM_RUSH) {
             if (teamIds.size() > 1) {
                 return CommandResult.failure(Component.empty()
                         .append(Component.text("Only one team can play "))
                         .append(Component.text(gameType.getTitle()))
-                        .append(Component.text(" at a time during practice mode.")));
+                        .append(Component.text(" at a time during practice mode."))
+                ).asFuture();
             }
         }
         return super.startGame(teamIds, gameAdmins, gameType, configFile);
     }
     
     @Override
-    public CommandResult joinParticipantToGame(@NotNull GameType gameType, @Nullable String configFile, @NotNull MCTParticipant participant) {
+    public CompletableFuture<CommandResult> joinParticipantToGame(@NotNull GameType gameType, @Nullable String configFile, @NotNull MCTParticipant participant) {
         if (configFile == null) {
-            return CommandResult.failure(Component.text("Please provide a valid config file"));
+            return CommandResult.failure(Component.text("Please provide a valid config file")).asFuture();
         }
         GameInstanceId id = new GameInstanceId(gameType, configFile);
         if (config.getPractice().isRestrictGameJoining()) {
@@ -195,42 +173,46 @@ public class PracticeState extends GameManagerState {
                 return super.joinParticipantToGame(gameType, configFile, participant);
             } else { // you're trying to join another team's game
                 return CommandResult.failure(Component.empty()
-                        .append(Component.text("Can't join another group's game")));
+                        .append(Component.text("Can't join another group's game"))
+                ).asFuture();
             }
         } else {
             if (id.getGameType() == GameType.FARM_RUSH) {
                 return CommandResult.failure(Component.empty()
                         .append(Component.text("Only one team can play "))
                         .append(Component.text(id.getTitle()))
-                        .append(Component.text(" at a time.")));
+                        .append(Component.text(" at a time."))
+                ).asFuture();
             }
             return super.joinParticipantToGame(gameType, configFile, participant);
         }
     }
     
     @Override
-    public CommandResult startEvent(@NotNull EventInfo eventInfo, int maxGames, int currentGameNumber) {
+    public CompletableFuture<CommandResult> startEvent(@NotNull EventInfo eventInfo, int maxGames, int currentGameNumber) {
         try {
             EventConfig eventConfig = new EventConfigController(plugin.getDataFolder()).getConfig();
             practiceManager.cleanup();
             context.setState(new ReadyUpState(context, contextReference, eventInfo, eventConfig, maxGames, currentGameNumber));
-            return CommandResult.success(Component.text("Switched to event mode"));
+            return CommandResult.success(Component.text("Switched to event mode")).asFuture();
         } catch (ConfigException e) {
             Main.logger().log(Level.SEVERE, e.getMessage(), e);
             return CommandResult.failure(Component.text("Can't switch to event mode. Error loading config file. See console for details:\n")
-                    .append(Component.text(e.getMessage())));
+                    .append(Component.text(e.getMessage()))
+            ).asFuture();
         }
     }
     
     // leave/join start
     
     @Override
-    public void onParticipantJoin(@NotNull MCTParticipant participant) {
-        super.onParticipantJoin(participant);
+    public CompletableFuture<Void> onParticipantJoin(@NotNull MCTParticipant participant) {
+        CompletableFuture<Void> joinFuture = super.onParticipantJoin(participant);
         if (!participant.getWorld().equals(config.getWorld())) {
             participant.teleport(config.getSpawn());
         }
         practiceManager.addParticipant(participant);
+        return joinFuture;
     }
     
     @Override
@@ -244,26 +226,29 @@ public class PracticeState extends GameManagerState {
     }
     
     @Override
-    public void onParticipantQuit(@NotNull MCTParticipant participant) {
+    public CompletableFuture<Void> onParticipantQuit(@NotNull MCTParticipant participant) {
         practiceManager.removeParticipant(participant.getUniqueId());
-        super.onParticipantQuit(participant);
+        return super.onParticipantQuit(participant);
     }
     
     // leave/join stop
     
     // team/participants management start
     @Override
-    public Team addTeam(String teamId, String teamDisplayName, String colorString) {
-        Team team = super.addTeam(teamId, teamDisplayName, colorString);
-        if (team != null) {
-            MCTTeam mctTeam = teams.get(teamId);
-            practiceManager.addTeam(mctTeam);
-        }
-        return team;
+    public CompletableFuture<Team> addTeam(String teamId, String teamDisplayName, String colorString) {
+        return super.addTeam(teamId, teamDisplayName, colorString)
+                .thenApplyAsync(team -> {
+                    if (team != null) {
+                        MCTTeam mctTeam = teams.get(teamId);
+                        practiceManager.addTeam(mctTeam);
+                    }
+                    return team;
+                }, context.getMainThreadExecutor())
+                ;
     }
     
     @Override
-    public CommandResult removeTeam(String teamId) {
+    public CompletableFuture<CommandResult> removeTeam(String teamId) {
         practiceManager.removeTeam(teamId);
         return super.removeTeam(teamId);
     }

--- a/src/main/java/org/braekpo1nt/mctmanager/games/gamemanager/states/event/EventState.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/gamemanager/states/event/EventState.java
@@ -32,6 +32,8 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.logging.Level;
 
 public abstract class EventState extends GameManagerState {
@@ -81,13 +83,11 @@ public abstract class EventState extends GameManagerState {
     }
     
     @Override
-    protected @NotNull CommandResult rebuildFromScores() throws SQLException {
-        try {
-            context.getGameStateService().rebuildEventMode(eventData.getEventInfo().getEventId());
-            return CommandResult.success(Component.text("Rebuilt game state from event mode"));
-        } catch (SQLException e) {
-            throw new SQLException("Unable to rebuild event mode", e);
-        }
+    protected @NotNull CompletableFuture<CommandResult> rebuildFromScores() {
+        return context.getGameStateService().rebuildEventMode(eventData.getEventInfo().getEventId())
+                .thenApply(v -> CommandResult.success(Component.text("Rebuilt game state from event mode")))
+                // no exceptionally block so that downstream can handle as they see fit
+                ;
     }
     
     @Override
@@ -107,40 +107,40 @@ public abstract class EventState extends GameManagerState {
     
     // event start
     @Override
-    public CommandResult startEvent(@NotNull EventInfo eventInfo, int maxGames, int currentGameNumber) {
-        return CommandResult.failure("Event is started");
+    public CompletableFuture<CommandResult> startEvent(@NotNull EventInfo eventInfo, int maxGames, int currentGameNumber) {
+        return CommandResult.failure("Event is started").asFuture();
     }
     
     @Override
-    public @NotNull CommandResult stopEvent() {
-        if (plugin.isEnabled()) {
-            plugin.getServer().getScheduler().runTaskAsynchronously(plugin,
-                    this::markEventAsStoppedInDatabase
-            );
-        } else {
-            markEventAsStoppedInDatabase();
-        }
-        return switchMode(Mode.MAINTENANCE);
+    public @NotNull CompletableFuture<CommandResult> stopEvent() {
+        return markEventAsStoppedInDatabase()
+                .exceptionally(e -> {
+                    Main.logger().log(Level.WARNING, "could not mark event as stopped in database");
+                    return null;
+                })
+                .thenApplyAsync(v -> switchMode(Mode.MAINTENANCE), plugin.getMainThreadExecutor());
     }
     
-    private void markEventAsStoppedInDatabase() {
-        try {
-            context.getEventService().updateActiveEvent(
-                    null,
-                    1,
-                    7
-            );
-        } catch (SQLException e) {
-            Main.logger().log(Level.WARNING, "Could not update active event ID in system_state table", e);
-        }
-        try {
-            context.getEventService().setEventEndTime(
-                    eventData.getEventInfo().getEventId(),
-                    new Date()
-            );
-        } catch (SQLException e) {
-            Main.logger().log(Level.WARNING, "Could set event end time", e);
-        }
+    private CompletableFuture<Void> markEventAsStoppedInDatabase() {
+        return CompletableFuture.runAsync(() -> {
+            try {
+                context.getEventService().updateActiveEvent(
+                        null,
+                        1,
+                        7
+                );
+            } catch (SQLException e) {
+                Main.logger().log(Level.WARNING, "Could not update active event ID in system_state table", e);
+            }
+            try {
+                context.getEventService().setEventEndTime(
+                        eventData.getEventInfo().getEventId(),
+                        new Date()
+                );
+            } catch (SQLException e) {
+                Main.logger().log(Level.WARNING, "Could set event end time", e);
+            }
+        }, plugin.getDatabaseExecutor());
     }
     
     @Override
@@ -236,30 +236,36 @@ public abstract class EventState extends GameManagerState {
     }
     
     @Override
-    public CommandResult modifyMaxGames(int newMaxGames) {
+    public CompletableFuture<CommandResult> modifyMaxGames(int newMaxGames) {
         if (newMaxGames < eventData.getCurrentGameNumber()) {
             return CommandResult.failure(Component.text("Can't set the max games for this event to less than ")
                     .append(Component.text(eventData.getCurrentGameNumber())
                             .decorate(TextDecoration.BOLD))
                     .append(Component.text(" because "))
                     .append(Component.text(eventData.getCurrentGameNumber()))
-                    .append(Component.text(" game(s) have been played.")));
+                    .append(Component.text(" game(s) have been played."))
+            ).asFuture();
         }
         eventData.setMaxGames(newMaxGames);
         sidebar.updateLine("currentGame", getCurrentGameLine());
-        plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
-            try {
-                context.getEventService().updateActiveEvent(
-                        eventData.getEventInfo().getEventId(),
-                        eventData.getCurrentGameNumber(),
-                        eventData.getMaxGames()
-                );
-            } catch (SQLException e) {
-                Main.logger().log(Level.SEVERE, "Could not update active currentGameNumber", e);
-            }
-        });
-        return CommandResult.success(Component.text("Max games has been set to ")
-                .append(Component.text(newMaxGames)));
+        return CompletableFuture.runAsync(() -> {
+                    try {
+                        context.getEventService().updateActiveEvent(
+                                eventData.getEventInfo().getEventId(),
+                                eventData.getCurrentGameNumber(),
+                                eventData.getMaxGames()
+                        );
+                    } catch (SQLException e) {
+                        throw new CompletionException(e);
+                    }
+                }, plugin.getDatabaseExecutor())
+                .exceptionally(e -> {
+                    Main.logger().log(Level.SEVERE, "Could not update active event info", e);
+                    return null;
+                })
+                .thenCompose(v -> CommandResult.success(Component.text("Max games has been set to ")
+                        .append(Component.text(newMaxGames))).asFuture())
+                ;
     }
     
     /**
@@ -351,19 +357,21 @@ public abstract class EventState extends GameManagerState {
     
     // leave/join start
     @Override
-    public void onParticipantJoin(@NotNull MCTParticipant participant) {
-        super.onParticipantJoin(participant);
+    public CompletableFuture<Void> onParticipantJoin(@NotNull MCTParticipant participant) {
+        CompletableFuture<Void> joinFuture = super.onParticipantJoin(participant);
         sidebar.updateLine(participant.getUniqueId(), "currentGame", getCurrentGameLine());
         Date date = new Date();
-        context.logScoreEvent(ScoreEvent.builder()
-                .sourceType(ScoreEvent.SourceType.SYSTEM)
-                .gameSessionId(null)
-                .participantUUID(participant.getUniqueId().toString())
-                .teamId(participant.getTeamId())
-                .pointsBase(0)
-                .description("joined event")
-                .createdAt(date)
-                .build());
+        return joinFuture.thenRunAsync(() -> {
+            context.logScoreEvent(ScoreEvent.builder()
+                    .sourceType(ScoreEvent.SourceType.SYSTEM)
+                    .gameSessionId(null)
+                    .participantUUID(participant.getUniqueId().toString())
+                    .teamId(participant.getTeamId())
+                    .pointsBase(0)
+                    .description("joined event")
+                    .createdAt(date)
+                    .build());
+        }, plugin.getDatabaseExecutor());
     }
     // leave/join stop
     

--- a/src/main/java/org/braekpo1nt/mctmanager/games/gamemanager/states/event/HalfTimeBreakState.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/gamemanager/states/event/HalfTimeBreakState.java
@@ -14,6 +14,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
 public class HalfTimeBreakState extends WaitingInHubState {
     public HalfTimeBreakState(@NotNull GameManager context, @NotNull ContextReference contextReference, @NotNull EventData eventData) {
@@ -21,8 +22,8 @@ public class HalfTimeBreakState extends WaitingInHubState {
     }
     
     @Override
-    public CommandResult startGame(@NotNull Set<String> teamIds, @NotNull List<Player> gameAdmins, @NotNull GameType gameType, @NotNull String configFile) {
-        return CommandResult.failure("Can't start a game during the half-time break");
+    public CompletableFuture<CommandResult> startGame(@NotNull Set<String> teamIds, @NotNull List<Player> gameAdmins, @NotNull GameType gameType, @NotNull String configFile) {
+        return CommandResult.failure("Can't start a game during the half-time break").asFuture();
     }
     
     @Override

--- a/src/main/java/org/braekpo1nt/mctmanager/games/gamemanager/states/event/PlayingGameState.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/gamemanager/states/event/PlayingGameState.java
@@ -2,16 +2,14 @@ package org.braekpo1nt.mctmanager.games.gamemanager.states.event;
 
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
+import org.braekpo1nt.mctmanager.Main;
 import org.braekpo1nt.mctmanager.commands.manager.commandresult.CommandResult;
-import org.braekpo1nt.mctmanager.commands.manager.commandresult.CompositeCommandResult;
-import org.braekpo1nt.mctmanager.commands.manager.commandresult.SuccessCommandResult;
 import org.braekpo1nt.mctmanager.games.game.enums.GameType;
 import org.braekpo1nt.mctmanager.games.gamemanager.GameInstanceId;
 import org.braekpo1nt.mctmanager.games.gamemanager.GameManager;
 import org.braekpo1nt.mctmanager.games.gamemanager.MCTParticipant;
 import org.braekpo1nt.mctmanager.games.gamemanager.event.EventData;
 import org.braekpo1nt.mctmanager.games.gamemanager.states.ContextReference;
-import org.braekpo1nt.mctmanager.participant.Participant;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
@@ -20,6 +18,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.logging.Level;
 
 public class PlayingGameState extends EventState {
     
@@ -37,16 +37,24 @@ public class PlayingGameState extends EventState {
     
     @Override
     public void enter() {
-        // TODO: have command startGame throw an UnableToStartGameException
-        // use the commandResult.message(sender) pattern, perhaps?
-        CommandResult commandResult = this.startGame(teams.keySet(), onlineAdmins, activeGameId.getGameType(), activeGameId.getConfigFile());
-        if (!(commandResult instanceof SuccessCommandResult)) {
-            context.messageAdmins(commandResult.getMessage());
-            context.messageOnlineParticipants(Component.empty()
-                    .append(Component.text("An error occurred starting the selected game. The admins are handling it.")
-                            .color(NamedTextColor.DARK_RED)));
-            context.setState(new WaitingInHubState(context, contextReference, eventData));
-        }
+        this.startGame(teams.keySet(), onlineAdmins, activeGameId.getGameType(), activeGameId.getConfigFile())
+                .thenAccept(commandResult -> {
+                    CommandResult.showResult(context.getOnlineAdmins(), commandResult);
+                })
+                .exceptionally(e -> {
+                    Main.logger().log(Level.SEVERE, "An error occurred starting the selected game. Returning to WaitingInHubState.", e);
+                    context.messageAdmins(Component.empty()
+                            .append(Component.text("An error occurred starting the selected game. See console for details."))
+                            .append(Component.newline())
+                            .append(Component.text(e.getMessage()))
+                            .color(NamedTextColor.DARK_RED)
+                    );
+                    context.messageOnlineParticipants(Component.empty()
+                            .append(Component.text("An error occurred starting the selected game. The admins are handling it.")
+                                    .color(NamedTextColor.DARK_RED)));
+                    context.setState(new WaitingInHubState(context, contextReference, eventData));
+                    return null;
+                });
     }
     
     @Override
@@ -55,30 +63,24 @@ public class PlayingGameState extends EventState {
     }
     
     @Override
-    protected void onGameInstantiationFailure(@NotNull GameInstanceId gameInstanceId, Collection<Participant> newParticipants, List<Player> newAdmins, Exception e) {
-        super.onGameInstantiationFailure(gameInstanceId, newParticipants, newAdmins, e);
-        context.setState(new WaitingInHubState(context, contextReference, eventData));
-    }
-    
-    @Override
     public void exit() {
         // do nothing
     }
     
     @Override
-    public void onParticipantJoin(@NotNull MCTParticipant participant) {
-        super.onParticipantJoin(participant);
-        CommandResult commandResult = joinParticipantToGame(activeGameId.getGameType(), activeGameId.getConfigFile(), participant);
-        if (!(commandResult instanceof SuccessCommandResult)) {
-            CompositeCommandResult adminResult = new CompositeCommandResult(CommandResult.failure(Component.empty()
-                    .append(Component.text("An error occurred joining "))
-                    .append(participant.displayName())
-                    .append(Component.text(" to "))
-                    .append(Component.text(activeGameId.getTitle()))
-                    .append(Component.text(":"))),
-                    commandResult);
-            context.messageAdmins(adminResult.getMessage());
-        }
+    public CompletableFuture<Void> onParticipantJoin(@NotNull MCTParticipant participant) {
+        return super.onParticipantJoin(participant)
+                .thenComposeAsync(
+                        v -> joinParticipantToGame(activeGameId.getGameType(), activeGameId.getConfigFile(), participant),
+                        context.getMainThreadExecutor()
+                )
+                .thenAccept(result -> CommandResult.showResult(plugin.getServer().getConsoleSender(), result))
+                .exceptionally(e -> {
+                    CommandResult adminResult = CommandResult.throwable(String.format("join %s to game %s", participant.displayName(), activeGameId.getTitle()), e);
+                    CommandResult.showResult(context.getOnlineAdmins(), adminResult);
+                    return null;
+                })
+                ;
     }
     
     @Override
@@ -89,17 +91,18 @@ public class PlayingGameState extends EventState {
     }
     
     @Override
-    public CommandResult startGame(@NotNull Set<String> teamIds, @NotNull List<Player> gameAdmins, @NotNull GameType gameType, @NotNull String configFile) {
+    public CompletableFuture<CommandResult> startGame(@NotNull Set<String> teamIds, @NotNull List<Player> gameAdmins, @NotNull GameType gameType, @NotNull String configFile) {
         if (!activeGames.isEmpty()) {
-            return CommandResult.failure("Only one game can be run at a time during an event");
+            return CommandResult.failure("Only one game can be run at a time during an event").asFuture();
         }
         return super.startGame(teamIds, gameAdmins, gameType, configFile);
     }
     
     @Override
-    public void gameIsOver(int gameSessionId, @NotNull GameInstanceId id, Map<String, Integer> teamScores, Map<UUID, Integer> participantScores, @NotNull Collection<UUID> gameParticipants, @NotNull List<Player> gameAdmins) {
-        super.gameIsOver(gameSessionId, id, teamScores, participantScores, gameParticipants, gameAdmins);
+    public CompletableFuture<Void> gameIsOver(int gameSessionId, @NotNull GameInstanceId id, Map<String, Integer> teamScores, Map<UUID, Integer> participantScores, @NotNull Collection<UUID> gameParticipants, @NotNull List<Player> gameAdmins) {
+        CompletableFuture<Void> gameIsOverFuture = super.gameIsOver(gameSessionId, id, teamScores, participantScores, gameParticipants, gameAdmins);
         postGame();
+        return gameIsOverFuture;
     }
     
     protected void postGame() {

--- a/src/main/java/org/braekpo1nt/mctmanager/games/gamemanager/states/event/PodiumState.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/gamemanager/states/event/PodiumState.java
@@ -12,6 +12,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
 public class PodiumState extends EventState {
     public PodiumState(@NotNull GameManager context, @NotNull ContextReference contextReference, @NotNull EventData eventData) {
@@ -54,8 +55,8 @@ public class PodiumState extends EventState {
     }
     
     @Override
-    public CommandResult startGame(@NotNull Set<String> teamIds, @NotNull List<Player> gameAdmins, @NotNull GameType gameType, @NotNull String configFile) {
-        return CommandResult.failure("Can't start a game, the event is over.");
+    public CompletableFuture<CommandResult> startGame(@NotNull Set<String> teamIds, @NotNull List<Player> gameAdmins, @NotNull GameType gameType, @NotNull String configFile) {
+        return CommandResult.failure("Can't start a game, the event is over.").asFuture();
     }
     
     @Override
@@ -64,8 +65,8 @@ public class PodiumState extends EventState {
     }
     
     @Override
-    public CommandResult modifyMaxGames(int newMaxGames) {
-        return CommandResult.failure(Component.text("The event is over, can't change the max games."));
+    public CompletableFuture<CommandResult> modifyMaxGames(int newMaxGames) {
+        return CommandResult.failure(Component.text("The event is over, can't change the max games.")).asFuture();
     }
     
     @Override
@@ -79,25 +80,27 @@ public class PodiumState extends EventState {
     }
     
     @Override
-    public void onParticipantJoin(@NotNull MCTParticipant participant) {
-        super.onParticipantJoin(participant);
+    public CompletableFuture<Void> onParticipantJoin(@NotNull MCTParticipant participant) {
+        CompletableFuture<Void> joinFuture = super.onParticipantJoin(participant);
         if (eventData.getWinningTeam() == null) {
-            return;
+            return joinFuture;
         }
         if (participant.getTeamId().equals(eventData.getWinningTeam().getTeamId())) {
             participant.teleport(config.getPodium());
             eventData.giveCrown(participant);
         }
+        return joinFuture;
     }
     
     @Override
-    public void onParticipantQuit(@NotNull MCTParticipant participant) {
+    public CompletableFuture<Void> onParticipantQuit(@NotNull MCTParticipant participant) {
+        // TODO: this looks like participants who quit in the podium state, when there isn't a winning team, won't be properly quit
         if (eventData.getWinningTeam() == null) {
-            return;
+            return CompletableFuture.completedFuture(null);
         }
         if (participant.getTeamId().equals(eventData.getWinningTeam().getTeamId())) {
             eventData.removeCrown(participant);
         }
-        super.onParticipantQuit(participant);
+        return super.onParticipantQuit(participant);
     }
 }

--- a/src/main/java/org/braekpo1nt/mctmanager/games/gamemanager/states/event/ReadyUpState.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/gamemanager/states/event/ReadyUpState.java
@@ -10,7 +10,6 @@ import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.title.Title;
 import org.braekpo1nt.mctmanager.Main;
 import org.braekpo1nt.mctmanager.commands.manager.commandresult.CommandResult;
-import org.braekpo1nt.mctmanager.commands.manager.commandresult.CompositeCommandResult;
 import org.braekpo1nt.mctmanager.database.entities.EventInfo;
 import org.braekpo1nt.mctmanager.database.entities.ScoreEvent;
 import org.braekpo1nt.mctmanager.games.game.enums.GameType;
@@ -31,11 +30,12 @@ import org.jetbrains.annotations.Nullable;
 
 import java.sql.SQLException;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.logging.Level;
 
 public class ReadyUpState extends EventState {
@@ -72,12 +72,17 @@ public class ReadyUpState extends EventState {
     @Override
     public void enter() {
         contextReference.getGameStateStorageUtil().eventMode(eventData.getEventInfo().getEventId());
-        context.stopAllGames();
+        CompletableFuture<CommandResult> chain = context.stopAllGames();
         for (MCTParticipant participant : onlineParticipants.values()) {
-            returnParticipantToHub(participant);
+            chain = CommandResult.appendAsync(
+                    chain,
+                    () -> returnParticipantToHub(participant),
+                    context.getMainThreadExecutor()
+            );
         }
         setupSidebar();
         sidebar.updateLine("currentGame", getCurrentGameLine());
+        // TODO: adding all the teams now is redundant because the gameState will be loaded and new teams will be added
         for (String teamId : teams.keySet()) {
             readyUpManager.addTeam(teamId);
         }
@@ -121,35 +126,42 @@ public class ReadyUpState extends EventState {
             }
         }.runTaskTimer(plugin, 0L, 2 * 20L).getTaskId();
         
-        CommandResult result = context.loadGameState();
-        CommandResult.showResult(contextReference.getPlugin().getServer().getConsoleSender(), result);
-        Date date = new Date();
-        context.logScoreEvents(allParticipants.values().stream()
-                .map(participant -> ScoreEvent.builder()
-                        .sourceType(ScoreEvent.SourceType.SYSTEM)
-                        .gameSessionId(null)
-                        .participantUUID(participant.getUniqueId().toString())
-                        .teamId(participant.getTeamId())
-                        .pointsBase(0)
-                        .description("joined event")
-                        .createdAt(date)
-                        .build())
-                .toList());
-        plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
-            try {
-                context.getEventService().updateActiveEvent(
-                        eventData.getEventInfo().getEventId(),
-                        eventData.getCurrentGameNumber(),
-                        eventData.getMaxGames()
-                );
-                context.getEventService().setEventStartTime(
-                        eventData.getEventInfo().getEventId(),
-                        new Date()
-                );
-            } catch (SQLException e) {
-                Main.logger().log(Level.SEVERE, "Could not update active event ID in system_state table", e);
-            }
-        });
+        chain
+                .thenCompose(v -> context.loadGameState())
+                .thenAccept(result -> {
+                    CommandResult.showResult(contextReference.getPlugin().getServer().getConsoleSender(), result);
+                })
+                .thenRunAsync(() -> {
+                    Date date = new Date();
+                    context.logScoreEvents(allParticipants.values().stream()
+                            .map(participant -> ScoreEvent.builder()
+                                    .sourceType(ScoreEvent.SourceType.SYSTEM)
+                                    .gameSessionId(null)
+                                    .participantUUID(participant.getUniqueId().toString())
+                                    .teamId(participant.getTeamId())
+                                    .pointsBase(0)
+                                    .description("joined event")
+                                    .createdAt(date)
+                                    .build())
+                            .toList());
+                    try {
+                        context.getEventService().updateActiveEvent(
+                                eventData.getEventInfo().getEventId(),
+                                eventData.getCurrentGameNumber(),
+                                eventData.getMaxGames()
+                        );
+                        context.getEventService().setEventStartTime(
+                                eventData.getEventInfo().getEventId(),
+                                new Date()
+                        );
+                    } catch (SQLException e) {
+                        throw new CompletionException(e);
+                    }
+                }, plugin.getDatabaseExecutor())
+                .exceptionally(e -> {
+                    Main.logger().log(Level.SEVERE, "Could not update active event ID in system_state table", e);
+                    return null;
+                });
     }
     
     @Override
@@ -187,22 +199,26 @@ public class ReadyUpState extends EventState {
     }
     
     @Override
-    public CommandResult startEvent(@NotNull EventInfo eventInfo, int maxGames, int currentGameNumber) {
+    public CompletableFuture<CommandResult> startEvent(@NotNull EventInfo eventInfo, int maxGames, int currentGameNumber) {
         if (contextReference.getOnlineParticipants().isEmpty()) {
-            return CommandResult.failure("There are no participants online. Can't start the event");
+            return CommandResult.failure("There are no participants online. Can't start the event").asFuture();
         }
         topbar.cleanup();
         plugin.getServer().getScheduler().cancelTask(readyUpPromptTaskId);
         readyUpManager.cleanup();
-        List<CommandResult> results = new ArrayList<>();
+        CompletableFuture<CommandResult> chain = CompletableFuture.completedFuture(CommandResult.success());
         if (maxGames != eventData.getMaxGames() || currentGameNumber != eventData.getCurrentGameNumber()) {
             eventData.setCurrentGameNumber(currentGameNumber);
-            results.add(this.modifyMaxGames(maxGames));
+            chain = CommandResult.appendAsync(
+                    chain,
+                    () -> modifyMaxGames(maxGames),
+                    plugin.getMainThreadExecutor()
+            );
         }
         Component message = Component.text("Starting event with ")
                 .append(Component.text(eventData.getMaxGames()))
                 .append(Component.text(" games."));
-        results.add(CommandResult.success(message));
+        chain = chain.thenApply(result -> result.and(CommandResult.success(message)));
         context.messageAdmins(message);
         Audience.audience(
                 onlineParticipants.values()
@@ -213,12 +229,12 @@ public class ReadyUpState extends EventState {
                         .color(NamedTextColor.GOLD)
         ));
         context.setState(new WaitingInHubState(context, contextReference, eventData));
-        return CompositeCommandResult.all(results);
+        return chain;
     }
     
     @Override
-    public CommandResult startGame(@NotNull Set<String> teamIds, @NotNull List<Player> gameAdmins, @NotNull GameType gameType, @NotNull String configFile) {
-        return CommandResult.failure("Can't start a game during this state.");
+    public CompletableFuture<CommandResult> startGame(@NotNull Set<String> teamIds, @NotNull List<Player> gameAdmins, @NotNull GameType gameType, @NotNull String configFile) {
+        return CommandResult.failure("Can't start a game during this state.").asFuture();
     }
     
     // readyup start
@@ -375,8 +391,8 @@ public class ReadyUpState extends EventState {
     // leave/join start
     
     @Override
-    public void onParticipantJoin(@NotNull MCTParticipant participant) {
-        super.onParticipantJoin(participant);
+    public CompletableFuture<Void> onParticipantJoin(@NotNull MCTParticipant participant) {
+        CompletableFuture<Void> joinFuture = super.onParticipantJoin(participant);
         String teamId = participant.getTeamId();
         MCTTeam team = teams.get(teamId);
         if (!readyUpManager.containsTeam(teamId) && team != null) {
@@ -386,13 +402,14 @@ public class ReadyUpState extends EventState {
         topbar.showPlayer(participant);
         unReadyParticipant(participant);
         participant.teleport(config.getSpawn());
+        return joinFuture;
     }
     
     @Override
-    public void onParticipantQuit(@NotNull MCTParticipant participant) {
+    public CompletableFuture<Void> onParticipantQuit(@NotNull MCTParticipant participant) {
         unReadyParticipant(participant);
         topbar.hidePlayer(participant);
-        super.onParticipantQuit(participant);
+        return super.onParticipantQuit(participant);
     }
     
     @Override

--- a/src/main/java/org/braekpo1nt/mctmanager/games/gamemanager/states/event/VotingState.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/gamemanager/states/event/VotingState.java
@@ -21,10 +21,12 @@ import org.bukkit.scheduler.BukkitTask;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
 public class VotingState extends EventState {
     
@@ -32,14 +34,19 @@ public class VotingState extends EventState {
     private static final int DISPLAY_VOTING_VOLUME = 50;
     private static final int DISPLAY_VOTING_PITCH = 30;
     private static final String FINAL_VOTING_SOUND = "entity.zombie_villager.cure";
-    private static final int FINAL_VOTING_VOLUME = 50;
+    private static final int FINAL_VOTING_VOLUME = 25;
     private static final int FINAL_VOTING_PITCH = 1;
     
     private final VoteManager voteManager;
     private final Timer timer;
+    private @NotNull final Random random;
     private @Nullable BukkitTask display;
     
     public VotingState(@NotNull GameManager context, @NotNull ContextReference contextReference, @NotNull EventData eventData) {
+        this(context, contextReference, eventData, new Random());
+    }
+    
+    public VotingState(@NotNull GameManager context, @NotNull ContextReference contextReference, @NotNull EventData eventData, @NotNull Random random) {
         super(context, contextReference, eventData);
         List<GameType> votingPool = getVotingPool();
         this.voteManager = new VoteManager(
@@ -61,6 +68,7 @@ public class VotingState extends EventState {
                     }
                 })
                 .build();
+        this.random = random;
     }
     
     @Override
@@ -89,13 +97,27 @@ public class VotingState extends EventState {
     
     protected void onVoteExecuted(List<GameType> gameTypes, String configFile) {
         timer.cancel();
+        List<GameType> votedForGames = gameTypes.isEmpty() ? getBackupGameType() : gameTypes;
         if (eventData.getConfig().isWeightedVoting()) {
-            Random random = new Random();
-            scheduleNextDisplay(gameTypes, configFile, 5, random, true);
+            scheduleNextDisplay(votedForGames, configFile, 5, true);
         } else {
-            GameType gameType = gameTypes.getFirst();
+            GameType gameType = votedForGames.getFirst();
             acceptVote(configFile, gameType);
         }
+    }
+    
+    /**
+     * @return a singleton list of a votable game as a backup for if no one voted for anything
+     */
+    private @NotNull List<GameType> getBackupGameType() {
+        List<GameType> votingPool = getVotingPool();
+        if (!votingPool.isEmpty()) {
+            int index = random.nextInt(votingPool.size());
+            return Collections.singletonList(votingPool.get(index));
+        }
+        List<GameType> votableGames = VoteManager.votableGames();
+        int index = random.nextInt(votableGames.size());
+        return Collections.singletonList(votableGames.get(index));
     }
     
     private void acceptVote(String configFile, GameType gameType) {
@@ -115,7 +137,7 @@ public class VotingState extends EventState {
         }
     }
     
-    public void scheduleNextDisplay(List<GameType> votes, String configFile, final long numberOfTicks, Random random, final boolean displayIsRed) {
+    public void scheduleNextDisplay(List<GameType> votes, String configFile, final long numberOfTicks, final boolean displayIsRed) {
         
         this.display = new BukkitRunnable() {
             @Override
@@ -181,21 +203,22 @@ public class VotingState extends EventState {
                     return;
                 }
                 if (!votes.isEmpty()) {
-                    scheduleNextDisplay(votes, configFile, nextNumberOfTicks, random, redTitle);
+                    scheduleNextDisplay(votes, configFile, nextNumberOfTicks, redTitle);
                 }
             }
         }.runTaskLater(plugin, numberOfTicks);
     }
     
     @Override
-    public CommandResult startGame(@NotNull Set<String> teamIds, @NotNull List<Player> gameAdmins, @NotNull GameType gameType, @NotNull String configFile) {
+    public CompletableFuture<CommandResult> startGame(@NotNull Set<String> teamIds, @NotNull List<Player> gameAdmins, @NotNull GameType gameType, @NotNull String configFile) {
         voteManager.cancelVote();
         timer.cancel();
         context.setState(new StartingGameDelayState(context, contextReference, eventData, gameType, configFile));
         return CommandResult.success(Component.empty()
                 .append(Component.text("Manually starting "))
                 .append(Component.text(gameType.getTitle()))
-                .append(Component.text(". Cancelling vote.")));
+                .append(Component.text(". Cancelling vote."))
+        ).asFuture();
     }
     
     @Override
@@ -209,16 +232,17 @@ public class VotingState extends EventState {
     }
     
     @Override
-    public void onParticipantJoin(@NotNull MCTParticipant participant) {
-        super.onParticipantJoin(participant);
+    public CompletableFuture<Void> onParticipantJoin(@NotNull MCTParticipant participant) {
+        CompletableFuture<Void> joinFuture = super.onParticipantJoin(participant);
         participant.teleport(config.getSpawn());
         voteManager.onParticipantJoin(participant);
+        return joinFuture;
     }
     
     @Override
-    public void onParticipantQuit(@NotNull MCTParticipant participant) {
+    public CompletableFuture<Void> onParticipantQuit(@NotNull MCTParticipant participant) {
         voteManager.onParticipantQuit(participant);
-        super.onParticipantQuit(participant);
+        return super.onParticipantQuit(participant);
     }
     
     @Override

--- a/src/main/java/org/braekpo1nt/mctmanager/games/gamemanager/states/event/WaitingInHubState.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/gamemanager/states/event/WaitingInHubState.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 
@@ -52,17 +54,22 @@ public class WaitingInHubState extends EventState {
         sidebar.updateLine("currentGame", getCurrentGameLine());
         context.getTimerManager().start(waitingInHubTimer);
         startActionBarTips();
-        plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
-            try {
-                context.getEventService().updateActiveEvent(
-                        eventData.getEventInfo().getEventId(),
-                        eventData.getCurrentGameNumber(),
-                        eventData.getMaxGames()
-                );
-            } catch (SQLException e) {
-                Main.logger().log(Level.SEVERE, "Could not update active currentGameNumber", e);
-            }
-        });
+        CompletableFuture.runAsync(() -> {
+                    try {
+                        context.getEventService().updateActiveEvent(
+                                eventData.getEventInfo().getEventId(),
+                                eventData.getCurrentGameNumber(),
+                                eventData.getMaxGames()
+                        );
+                    } catch (SQLException e) {
+                        throw new CompletionException(e);
+                    }
+                }, plugin.getDatabaseExecutor())
+                .exceptionally(e -> {
+                    Main.logger().log(Level.SEVERE, "Could not update active currentGameNumber", e);
+                    
+                    return null;
+                });
     }
     
     @Override
@@ -114,14 +121,15 @@ public class WaitingInHubState extends EventState {
     }
     
     @Override
-    public CommandResult startGame(@NotNull Set<String> teamIds, @NotNull List<Player> gameAdmins, @NotNull GameType gameType, @NotNull String configFile) {
+    public CompletableFuture<CommandResult> startGame(@NotNull Set<String> teamIds, @NotNull List<Player> gameAdmins, @NotNull GameType gameType, @NotNull String configFile) {
         waitingInHubTimer.cancel();
         disableTips();
         context.setState(new StartingGameDelayState(context, contextReference, eventData, gameType, configFile));
         return CommandResult.success(Component.empty()
                 .append(Component.text("Manually starting "))
                 .append(Component.text(gameType.getTitle()))
-                .append(Component.text(". Cancelling the vote.")));
+                .append(Component.text(". Cancelling the vote."))
+        ).asFuture();
     }
     
     public void startActionBarTips() {
@@ -154,10 +162,10 @@ public class WaitingInHubState extends EventState {
     }
     
     @Override
-    public void onParticipantJoin(@NotNull MCTParticipant participant) {
-        super.onParticipantJoin(participant);
+    public CompletableFuture<Void> onParticipantJoin(@NotNull MCTParticipant participant) {
+        CompletableFuture<Void> joinFuture = super.onParticipantJoin(participant);
         participant.teleport(config.getSpawn());
-        
+        return joinFuture;
     }
     
     /**

--- a/src/main/java/org/braekpo1nt/mctmanager/games/gamemanager/states/event/delay/DelayState.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/gamemanager/states/event/delay/DelayState.java
@@ -12,6 +12,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
 public abstract class DelayState extends EventState {
     public DelayState(@NotNull GameManager context, @NotNull ContextReference contextReference, @NotNull EventData eventData) {
@@ -19,13 +20,14 @@ public abstract class DelayState extends EventState {
     }
     
     @Override
-    public CommandResult startGame(@NotNull Set<String> teamIds, @NotNull List<Player> gameAdmins, @NotNull GameType gameType, @NotNull String configFile) {
-        return CommandResult.failure("Can't start a game during a delay state");
+    public CompletableFuture<CommandResult> startGame(@NotNull Set<String> teamIds, @NotNull List<Player> gameAdmins, @NotNull GameType gameType, @NotNull String configFile) {
+        return CommandResult.failure("Can't start a game during a delay state").asFuture();
     }
     
     @Override
-    public void onParticipantJoin(@NotNull MCTParticipant participant) {
-        super.onParticipantJoin(participant);
+    public CompletableFuture<Void> onParticipantJoin(@NotNull MCTParticipant participant) {
+        CompletableFuture<Void> joinFuture = super.onParticipantJoin(participant);
         participant.teleport(config.getSpawn());
+        return joinFuture;
     }
 }

--- a/src/main/java/org/braekpo1nt/mctmanager/games/gamestate/GameStateStorageUtil.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/gamestate/GameStateStorageUtil.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
+import org.braekpo1nt.mctmanager.Main;
 import org.braekpo1nt.mctmanager.config.exceptions.ConfigIOException;
 import org.braekpo1nt.mctmanager.config.exceptions.ConfigInvalidException;
 import org.braekpo1nt.mctmanager.database.entities.admin.ActiveAdminEntity;
@@ -12,7 +13,6 @@ import org.braekpo1nt.mctmanager.database.entities.teams.ActiveTeam;
 import org.braekpo1nt.mctmanager.database.service.GameStateService;
 import org.braekpo1nt.mctmanager.database.service.RegisterConflictType;
 import org.braekpo1nt.mctmanager.games.gamemanager.GameManager;
-import org.braekpo1nt.mctmanager.games.gamemanager.MCTTeam;
 import org.braekpo1nt.mctmanager.games.gamestate.states.SUEventState;
 import org.braekpo1nt.mctmanager.games.gamestate.states.SUMaintenanceState;
 import org.braekpo1nt.mctmanager.games.gamestate.states.SUPracticeState;
@@ -37,6 +37,10 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -48,6 +52,8 @@ public class GameStateStorageUtil {
     protected final Logger LOGGER;
     @Getter
     protected final GameStateService gameStateService;
+    @Getter
+    protected final Executor databaseExecutor;
     /**
      * A flag that is only needed because the tests use sqlite, and production uses mariaDB.
      * Specifically regarding the portability miss-match in conflict resolution during upsert operations.
@@ -58,14 +64,15 @@ public class GameStateStorageUtil {
     protected GameState gameState = new GameState(new HashMap<>(), new HashMap<>(), new ArrayList<>());
     protected @NotNull StorageUtilState state;
     
-    public GameStateStorageUtil(@NotNull Logger logger, @NotNull GameStateService gameStateService) {
-        this(logger, gameStateService, true);
+    public GameStateStorageUtil(@NotNull Logger logger, @NotNull GameStateService gameStateService, @NotNull Executor databaseExecutor) {
+        this(logger, gameStateService, databaseExecutor, true);
     }
     
-    public GameStateStorageUtil(@NotNull Logger logger, @NotNull GameStateService gameStateService, boolean mariaDB) {
+    public GameStateStorageUtil(@NotNull Logger logger, @NotNull GameStateService gameStateService, @NotNull Executor databaseExecutor, boolean mariaDB) {
         this.LOGGER = logger;
         // Pro Tip: The plugin.getGameManager() is null at this point
         this.gameStateService = gameStateService;
+        this.databaseExecutor = databaseExecutor;
         this.mariaDB = mariaDB;
         this.state = new SUMaintenanceState(this);
         state.enter();
@@ -97,10 +104,40 @@ public class GameStateStorageUtil {
      * - reading the existing game state file
      * - parsing the game state from json
      */
-    public void loadGameState() throws SQLException {
-        this.gameState = constructGameStateFromDatabase();
-        gameStateService.setActiveVersion(0);
-        LOGGER.info("Constructed game state from database");
+    public CompletableFuture<Void> loadGameState() throws SQLException {
+        return constructGameStateFromDatabase()
+                .thenAccept(gameState -> {
+                    // yes, this successfully assigns the gameState to this.gameState even though it's threaded operation.
+                    // You are guaranteed to have this.gameState updated provided you wait till the completion of this
+                    // future, e.g. {@code .thenApply} or {@code .thenRunAsync} etc. with proper chaining
+                    // You only need to label this.gameState as volatile if unrelated threads (improperly chained) access it
+                    this.gameState = gameState;
+                    LOGGER.info("Constructed game state from database");
+                })
+                .thenAcceptAsync(gameState -> {
+                    try {
+                        gameStateService.setActiveVersion(0);
+                    } catch (SQLException e) {
+                        Main.logger().log(Level.WARNING, "database exception while trying to set the active version", e);
+                    }
+                }, databaseExecutor)
+                .exceptionally(e -> {
+                    Main.logger().log(Level.SEVERE, "Unable to load gameState from database", e);
+                    return null;
+                });
+    }
+    
+    private @NotNull CompletableFuture<GameState> constructGameStateFromDatabase() {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                List<ActiveTeam> activeTeams = gameStateService.getActiveTeams();
+                List<ActiveParticipant> activeParticipants = gameStateService.getActiveParticipants();
+                List<ActiveAdminEntity> adminEntities = gameStateService.getActiveAdmins();
+                return new GameState(ActiveParticipant.toPlayers(activeParticipants), ActiveTeam.toTeams(activeTeams), ActiveAdminEntity.toAdmins(adminEntities));
+            } catch (SQLException e) {
+                throw new CompletionException(e);
+            }
+        }, databaseExecutor);
     }
     
     public Component printGameState() {
@@ -143,13 +180,6 @@ public class GameStateStorageUtil {
         return builder.build();
     }
     
-    private @NotNull GameState constructGameStateFromDatabase() throws SQLException {
-        List<ActiveTeam> activeTeams = gameStateService.getActiveTeams();
-        List<ActiveParticipant> activeParticipants = gameStateService.getActiveParticipants();
-        List<ActiveAdminEntity> adminEntities = gameStateService.getActiveAdmins();
-        return new GameState(ActiveParticipant.toPlayers(activeParticipants), ActiveTeam.toTeams(activeTeams), ActiveAdminEntity.toAdmins(adminEntities));
-    }
-    
     /**
      * Add a team to the game state.
      * @param teamId The internal name of the team.
@@ -158,12 +188,12 @@ public class GameStateStorageUtil {
      * @return the score of the team (based on historical data)
      * @throws ConfigIOException If there is an error saving the game state while adding a new team.
      */
-    public int addTeam(String teamId, String teamDisplayName, String color) throws SQLException {
+    public CompletableFuture<Integer> addTeam(String teamId, String teamDisplayName, String color) {
         return state.addTeam(teamId, teamDisplayName, color);
     }
     
-    public void removeTeam(String teamId) throws SQLException {
-        state.removeTeam(teamId);
+    public CompletableFuture<Void> removeTeam(String teamId) {
+        return state.removeTeam(teamId);
     }
     
     /**
@@ -291,13 +321,13 @@ public class GameStateStorageUtil {
     
     /**
      * Adds the given player to the game state, joined to the given team
-     * @param playerToJoin the UUID of the player
+     * @param uuid the UUID of the player
      * @param ign the ign of the player
      * @param teamId the teamId to join it to
      * @throws ConfigIOException if there is an IO error saving the game state
      */
-    public int addNewPlayer(@NotNull UUID playerToJoin, @NotNull String ign, @NotNull String teamId) throws SQLException {
-        return state.addNewPlayer(playerToJoin, ign, teamId);
+    public CompletableFuture<Integer> joinPlayer(@NotNull UUID uuid, @NotNull String ign, @NotNull String teamId) {
+        return state.joinPlayer(uuid, ign, teamId);
     }
     
     /**
@@ -344,9 +374,9 @@ public class GameStateStorageUtil {
      * database. Meant to be called after {@link #updateScores(Collection, Collection)}
      * @param teams the teams to update
      * @param participants the participants to update
-     * @throws Exception if there is an issue communicating with the database
      */
-    public void persistScores(Collection<org.braekpo1nt.mctmanager.games.gamemanager.MCTTeam> teams, Collection<OfflineParticipant> participants) throws Exception {
+    @SuppressWarnings("UnusedReturnValue")
+    public CompletableFuture<Void> persistScores(Collection<org.braekpo1nt.mctmanager.games.gamemanager.MCTTeam> teams, Collection<OfflineParticipant> participants) {
         List<ActiveTeam> activeTeams = teams.stream()
                 .map(team -> {
                     MCTTeamEntity mctTeamEntity = gameState.getTeam(team.getTeamId());
@@ -361,65 +391,60 @@ public class GameStateStorageUtil {
                 })
                 .filter(Objects::nonNull)
                 .toList();
-        persistScores(activeParticipants, activeTeams);
+        return persistScores(activeParticipants, activeTeams);
     }
     
     /**
      * @param activeParticipants the participants to commit to the database
      * @param activeTeams the teams to commit to the database
-     * @throws Exception if there is an issue communicating with the database
      */
-    protected void persistScores(List<ActiveParticipant> activeParticipants, List<ActiveTeam> activeTeams) throws Exception {
-        gameStateService.updateActiveParticipants(activeParticipants);
-        gameStateService.updateActiveTeams(activeTeams);
+    protected CompletableFuture<Void> persistScores(List<ActiveParticipant> activeParticipants, List<ActiveTeam> activeTeams) {
+        return CompletableFuture.runAsync(() -> {
+            try {
+                gameStateService.updateActiveParticipants(activeParticipants);
+                gameStateService.updateActiveTeams(activeTeams);
+            } catch (Exception e) {
+                Main.logger().log(Level.SEVERE, String.format("Unable to persist scores of %s participants and %s teams", activeParticipants.size(), activeTeams.size()), e);
+            }
+        }, databaseExecutor);
     }
     
     /**
      * Update the score of the given participant in-memory.
-     * Meant to be used in combination with {@link #persistScore(OfflineParticipant)}, or
-     * the score won't be persisted to the database.
+     * Asynchronously persist the score of the given participant in the database.
      * @param participant the participant to update the score of
      */
-    public void updateScore(OfflineParticipant participant) {
-        MCTPlayerEntity player = Objects.requireNonNull(gameState.getPlayer(participant.getUniqueId()),
-                "attempted to update score of non-existent participant");
-        player.setScore(participant.getScore());
-    }
-    
-    /**
-     * Persist the score of the given participant in the database.
-     * Meant to be called after {@link #updateScore(OfflineParticipant)} in a different thread so
-     * that the persistence doesn't lag the game.
-     * @param participant the participant to update the score of
-     * @throws SQLException if there's an issue communicating with the database
-     */
-    public void persistScore(OfflineParticipant participant) throws SQLException {
+    @SuppressWarnings("UnusedReturnValue")
+    public CompletableFuture<Void> persistScore(OfflineParticipant participant) {
         MCTPlayerEntity player = Objects.requireNonNull(gameState.getPlayer(participant.getUniqueId()),
                 "attempted to persist score of non-existent participant");
-        gameStateService.updateActiveParticipant(ActiveParticipant.fromPlayer(player));
+        player.setScore(participant.getScore());
+        return CompletableFuture.runAsync(() -> {
+            try {
+                gameStateService.updateActiveParticipant(ActiveParticipant.fromPlayer(player));
+            } catch (Exception e) {
+                Main.logger().log(Level.SEVERE, String.format("Unable to persist scores of participant %s score=%s", player.getName(), player.getScore()), e);
+            }
+        }, databaseExecutor);
     }
     
     /**
      * Update the score of the given team in-memory.
-     * Meant to be used in combination with {@link #persistScore(MCTTeam)}, or
-     * the score won't be persisted to the database.
+     * Asynchronously persist the score of the given team in the database.
      * @param mctTeam the team to update the score of
      */
-    public void updateScore(org.braekpo1nt.mctmanager.games.gamemanager.MCTTeam mctTeam) {
-        MCTTeamEntity team = gameState.getTeam(mctTeam.getTeamId());
+    @SuppressWarnings("UnusedReturnValue")
+    public CompletableFuture<Void> persistScore(org.braekpo1nt.mctmanager.games.gamemanager.MCTTeam mctTeam) {
+        MCTTeamEntity team = Objects.requireNonNull(gameState.getTeam(mctTeam.getTeamId()),
+                "attempted to persist score of non-existent team");
         team.setScore(mctTeam.getScore());
-    }
-    
-    /**
-     * Persist the score of the given team in the database.
-     * Meant to be called after {@link #updateScore(MCTTeam)} in a different thread so
-     * that the persistence doesn't lag the game.
-     * @param mctTeam the team to update the score of
-     * @throws SQLException if there's an issue communicating with the database
-     */
-    public void persistScore(org.braekpo1nt.mctmanager.games.gamemanager.MCTTeam mctTeam) throws SQLException {
-        MCTTeamEntity team = gameState.getTeam(mctTeam.getTeamId());
-        gameStateService.updateActiveTeam(ActiveTeam.fromTeam(team));
+        return CompletableFuture.runAsync(() -> {
+            try {
+                gameStateService.updateActiveTeam(ActiveTeam.fromTeam(team));
+            } catch (Exception e) {
+                Main.logger().log(Level.SEVERE, String.format("Unable to persist scores of team %s score=%s", team.getName(), team.getScore()), e);
+            }
+        }, databaseExecutor);
     }
     
     /**
@@ -443,8 +468,8 @@ public class GameStateStorageUtil {
      * @param playerUniqueId The UUID for the player
      * @throws ConfigIOException if there is an IO error saving the game state
      */
-    public void leavePlayer(UUID playerUniqueId) throws SQLException {
-        state.leavePlayer(playerUniqueId);
+    public CompletableFuture<Void> leavePlayer(UUID playerUniqueId) {
+        return state.leavePlayer(playerUniqueId);
     }
     
     public @NotNull NamedTextColor getTeamColor(@NotNull String teamId) {
@@ -491,10 +516,9 @@ public class GameStateStorageUtil {
     
     /**
      * @return a map from UUID to Admin Names
-     * @throws SQLException if there's a SQL error
      */
-    public @NotNull Map<UUID, String> getAllAdminNames() throws SQLException {
-        return gameStateService.getAdminNames();
+    public @NotNull CompletableFuture<Map<UUID, String>> getAllAdminNames() {
+        return state.getAllAdminNames();
     }
     
     /**
@@ -511,8 +535,8 @@ public class GameStateStorageUtil {
      * @param adminUniqueId the unique id of the admin
      * @throws ConfigIOException If there is an issue saving the game state
      */
-    public void removeAdmin(UUID adminUniqueId) throws SQLException {
-        state.removeAdmin(adminUniqueId);
+    public CompletableFuture<Void> removeAdmin(UUID adminUniqueId) {
+        return state.removeAdmin(adminUniqueId);
     }
     
     public void setIGN(UUID uuid, String ign) throws SQLException {
@@ -521,7 +545,6 @@ public class GameStateStorageUtil {
             return;
         }
         player.setName(ign);
-        // TODO: should we update the name in the database here, or separately outside? Last decision was to keep it here
         gameStateService.migrateIgn(uuid.toString(), ign);
     }
 }

--- a/src/main/java/org/braekpo1nt/mctmanager/games/gamestate/states/SUEventState.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/gamestate/states/SUEventState.java
@@ -1,6 +1,5 @@
 package org.braekpo1nt.mctmanager.games.gamestate.states;
 
-import org.braekpo1nt.mctmanager.database.entities.admin.ActiveAdminEntity;
 import org.braekpo1nt.mctmanager.database.entities.admin.EventAdminEntity;
 import org.braekpo1nt.mctmanager.games.gamestate.GameStateStorageUtil;
 import org.braekpo1nt.mctmanager.games.gamestate.MCTPlayerEntity;
@@ -8,7 +7,7 @@ import org.braekpo1nt.mctmanager.games.gamestate.MCTTeamEntity;
 import org.jetbrains.annotations.NotNull;
 
 import java.sql.SQLException;
-import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public class SUEventState extends StorageUtilState {
@@ -34,20 +33,13 @@ public class SUEventState extends StorageUtilState {
      * {@inheritDoc}
      */
     @Override
-    public int addTeam(String teamId, String teamDisplayName, String color) throws SQLException {
-        MCTTeamEntity team = context.getGameState().addTeam(teamId, teamDisplayName, color);
+    protected int persistAddTeam(String teamId, MCTTeamEntity team) throws SQLException {
         context.getGameStateService().addTeam(team.toEvent(eventId));
-        int score = context.getGameStateService().rebuildEventTeam(teamId, eventId, context.isMariaDB());
-        team.setScore(score);
-        return score;
+        return context.getGameStateService().rebuildEventTeam(teamId, eventId, context.isMariaDB());
     }
     
     @Override
-    public void removeTeam(String teamId) throws SQLException {
-        List<UUID> uuidsOnTeam = context.getParticipantUUIDsOnTeam(teamId);
-        context.getGameState().removePlayers(uuidsOnTeam);
-        context.getGameState().removeTeam(teamId);
-        context.getGameStateService().deleteTeam(teamId);
+    protected void persistRemoveTeam(String teamId) throws SQLException {
         context.getGameStateService().deleteEventTeam(teamId, eventId);
     }
     
@@ -55,27 +47,18 @@ public class SUEventState extends StorageUtilState {
      * {@inheritDoc}
      */
     @Override
-    public int addNewPlayer(@NotNull UUID uuid, @NotNull String ign, @NotNull String teamId) throws SQLException {
-        MCTPlayerEntity player = context.getGameState().addPlayer(uuid, ign, teamId);
+    protected int persistJoinPlayer(@NotNull UUID uuid, MCTPlayerEntity player) throws SQLException {
         context.getGameStateService().addParticipant(player.toEvent(eventId), player.getName());
-        int score = context.getGameStateService().rebuildEventParticipant(uuid.toString(), eventId);
-        player.setScore(score);
-        return score;
+        return context.getGameStateService().rebuildEventParticipant(uuid.toString(), eventId);
     }
     
     @Override
-    public void leavePlayer(UUID playerUniqueId) throws SQLException {
-        context.getGameState().removePlayer(playerUniqueId);
-        String uuid = playerUniqueId.toString();
-        context.getGameStateService().deleteParticipant(uuid);
-        context.getGameStateService().deleteEventParticipant(uuid, eventId);
+    public void persistLeavePlayer(@NotNull String uuidString) throws SQLException {
+        context.getGameStateService().deleteEventParticipant(uuidString, eventId);
     }
     
     @Override
-    public void addAdmin(UUID adminUniqueId) throws SQLException {
-        context.getGameState().addAdmin(adminUniqueId);
-        String uuid = adminUniqueId.toString();
-        context.getGameStateService().addAdmin(new ActiveAdminEntity(uuid));
+    public void persistAddAdmin(@NotNull String uuid) throws SQLException {
         context.getGameStateService().addAdmin(EventAdminEntity.builder()
                 .eventId(eventId)
                 .uuid(uuid)
@@ -83,10 +66,12 @@ public class SUEventState extends StorageUtilState {
     }
     
     @Override
-    public void removeAdmin(UUID adminUniqueId) throws SQLException {
-        context.getGameState().removeAdmin(adminUniqueId);
-        String uuid = adminUniqueId.toString();
-        context.getGameStateService().deleteActiveAdmin(uuid);
+    public void persistRemoveAdmin(@NotNull String uuid) throws SQLException {
         context.getGameStateService().deleteEventAdmin(uuid, eventId);
+    }
+    
+    @Override
+    protected @NotNull Map<UUID, String> getAdminNames() throws SQLException {
+        return context.getGameStateService().getEventAdminNames(eventId);
     }
 }

--- a/src/main/java/org/braekpo1nt/mctmanager/games/gamestate/states/SUMaintenanceState.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/gamestate/states/SUMaintenanceState.java
@@ -1,7 +1,5 @@
 package org.braekpo1nt.mctmanager.games.gamestate.states;
 
-import org.braekpo1nt.mctmanager.config.exceptions.ConfigIOException;
-import org.braekpo1nt.mctmanager.database.entities.admin.ActiveAdminEntity;
 import org.braekpo1nt.mctmanager.database.entities.admin.MaintenanceAdminEntity;
 import org.braekpo1nt.mctmanager.games.gamestate.GameStateStorageUtil;
 import org.braekpo1nt.mctmanager.games.gamestate.MCTPlayerEntity;
@@ -9,7 +7,7 @@ import org.braekpo1nt.mctmanager.games.gamestate.MCTTeamEntity;
 import org.jetbrains.annotations.NotNull;
 
 import java.sql.SQLException;
-import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public class SUMaintenanceState extends StorageUtilState {
@@ -32,20 +30,13 @@ public class SUMaintenanceState extends StorageUtilState {
      * {@inheritDoc}
      */
     @Override
-    public int addTeam(String teamId, String teamDisplayName, String color) throws SQLException {
-        MCTTeamEntity team = context.getGameState().addTeam(teamId, teamDisplayName, color);
+    protected int persistAddTeam(String teamId, MCTTeamEntity team) throws SQLException {
         context.getGameStateService().addTeam(team.toMaintenance());
-        int score = context.getGameStateService().rebuildMaintenanceTeam(teamId, context.isMariaDB());
-        team.setScore(score);
-        return score;
+        return context.getGameStateService().rebuildMaintenanceTeam(teamId, context.isMariaDB());
     }
     
     @Override
-    public void removeTeam(String teamId) throws SQLException {
-        List<UUID> uuidsOnTeam = context.getParticipantUUIDsOnTeam(teamId);
-        context.getGameState().removePlayers(uuidsOnTeam);
-        context.getGameState().removeTeam(teamId);
-        context.getGameStateService().deleteTeam(teamId);
+    protected void persistRemoveTeam(String teamId) throws SQLException {
         context.getGameStateService().deleteMaintenanceTeam(teamId);
     }
     
@@ -53,37 +44,28 @@ public class SUMaintenanceState extends StorageUtilState {
      * {@inheritDoc}
      */
     @Override
-    public int addNewPlayer(@NotNull UUID uuid, @NotNull String ign, @NotNull String teamId) throws ConfigIOException, SQLException {
-        MCTPlayerEntity player = context.getGameState().addPlayer(uuid, ign, teamId);
+    protected int persistJoinPlayer(@NotNull UUID uuid, MCTPlayerEntity player) throws SQLException {
         context.getGameStateService().addParticipant(player.toMaintenance(), player.getName());
-        int score = context.getGameStateService().rebuildMaintenanceParticipant(uuid.toString());
-        player.setScore(score);
-        return score;
-        // TODO: write a test to make sure the ActiveParticipant row is added to the active_participants table every time, and you don't have to add the below line. Do so for all states
-//        context.getGameStateService().addParticipant(ActiveParticipant.fromPlayer(player));
+        return context.getGameStateService().rebuildMaintenanceParticipant(uuid.toString());
     }
     
     @Override
-    public void leavePlayer(UUID playerUniqueId) throws SQLException {
-        context.getGameState().removePlayer(playerUniqueId);
-        String uuid = playerUniqueId.toString();
-        context.getGameStateService().deleteParticipant(uuid);
-        context.getGameStateService().deleteMaintenanceParticipant(uuid);
+    public void persistLeavePlayer(@NotNull String uuidString) throws SQLException {
+        context.getGameStateService().deleteMaintenanceParticipant(uuidString);
     }
     
     @Override
-    public void addAdmin(UUID adminUniqueId) throws SQLException {
-        context.getGameState().addAdmin(adminUniqueId);
-        String uuid = adminUniqueId.toString();
-        context.getGameStateService().addAdmin(new ActiveAdminEntity(uuid));
+    public void persistAddAdmin(@NotNull String uuid) throws SQLException {
         context.getGameStateService().addAdmin(new MaintenanceAdminEntity(uuid));
     }
     
     @Override
-    public void removeAdmin(UUID adminUniqueId) throws SQLException {
-        context.getGameState().removeAdmin(adminUniqueId);
-        String uuid = adminUniqueId.toString();
-        context.getGameStateService().deleteActiveAdmin(uuid);
+    public void persistRemoveAdmin(@NotNull String uuid) throws SQLException {
         context.getGameStateService().deleteMaintenanceAdmin(uuid);
+    }
+    
+    @Override
+    protected @NotNull Map<UUID, String> getAdminNames() throws SQLException {
+        return context.getGameStateService().getMaintenanceAdminNames();
     }
 }

--- a/src/main/java/org/braekpo1nt/mctmanager/games/gamestate/states/SUPracticeState.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/gamestate/states/SUPracticeState.java
@@ -1,6 +1,5 @@
 package org.braekpo1nt.mctmanager.games.gamestate.states;
 
-import org.braekpo1nt.mctmanager.database.entities.admin.ActiveAdminEntity;
 import org.braekpo1nt.mctmanager.database.entities.admin.PracticeAdminEntity;
 import org.braekpo1nt.mctmanager.games.gamestate.GameStateStorageUtil;
 import org.braekpo1nt.mctmanager.games.gamestate.MCTPlayerEntity;
@@ -8,7 +7,7 @@ import org.braekpo1nt.mctmanager.games.gamestate.MCTTeamEntity;
 import org.jetbrains.annotations.NotNull;
 
 import java.sql.SQLException;
-import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public class SUPracticeState extends StorageUtilState {
@@ -31,20 +30,13 @@ public class SUPracticeState extends StorageUtilState {
      * {@inheritDoc}
      */
     @Override
-    public int addTeam(String teamId, String teamDisplayName, String color) throws SQLException {
-        MCTTeamEntity team = context.getGameState().addTeam(teamId, teamDisplayName, color);
+    protected int persistAddTeam(String teamId, MCTTeamEntity team) throws SQLException {
         context.getGameStateService().addTeam(team.toPractice());
-        int score = context.getGameStateService().rebuildPracticeTeam(teamId, context.isMariaDB());
-        team.setScore(score);
-        return score;
+        return context.getGameStateService().rebuildPracticeTeam(teamId, context.isMariaDB());
     }
     
     @Override
-    public void removeTeam(String teamId) throws SQLException {
-        List<UUID> uuidsOnTeam = context.getParticipantUUIDsOnTeam(teamId);
-        context.getGameState().removePlayers(uuidsOnTeam);
-        context.getGameState().removeTeam(teamId);
-        context.getGameStateService().deleteTeam(teamId);
+    protected void persistRemoveTeam(String teamId) throws SQLException {
         context.getGameStateService().deletePracticeTeam(teamId);
     }
     
@@ -52,35 +44,28 @@ public class SUPracticeState extends StorageUtilState {
      * {@inheritDoc}
      */
     @Override
-    public int addNewPlayer(@NotNull UUID uuid, @NotNull String ign, @NotNull String teamId) throws SQLException {
-        MCTPlayerEntity player = context.getGameState().addPlayer(uuid, ign, teamId);
+    protected int persistJoinPlayer(@NotNull UUID uuid, MCTPlayerEntity player) throws SQLException {
         context.getGameStateService().addParticipant(player.toPractice(), player.getName());
-        int score = context.getGameStateService().rebuildPracticeParticipant(uuid.toString());
-        player.setScore(score);
-        return score;
+        return context.getGameStateService().rebuildPracticeParticipant(uuid.toString());
     }
     
     @Override
-    public void leavePlayer(UUID playerUniqueId) throws SQLException {
-        context.getGameState().removePlayer(playerUniqueId);
-        String uuid = playerUniqueId.toString();
-        context.getGameStateService().deleteParticipant(uuid);
-        context.getGameStateService().deletePracticeParticipant(uuid);
+    public void persistLeavePlayer(@NotNull String uuidString) throws SQLException {
+        context.getGameStateService().deletePracticeParticipant(uuidString);
     }
     
     @Override
-    public void addAdmin(UUID adminUniqueId) throws SQLException {
-        context.getGameState().addAdmin(adminUniqueId);
-        String uuid = adminUniqueId.toString();
-        context.getGameStateService().addAdmin(new ActiveAdminEntity(uuid));
+    public void persistAddAdmin(@NotNull String uuid) throws SQLException {
         context.getGameStateService().addAdmin(new PracticeAdminEntity(uuid));
     }
     
     @Override
-    public void removeAdmin(UUID adminUniqueId) throws SQLException {
-        context.getGameState().removeAdmin(adminUniqueId);
-        String uuid = adminUniqueId.toString();
-        context.getGameStateService().deleteActiveAdmin(uuid);
+    public void persistRemoveAdmin(@NotNull String uuid) throws SQLException {
         context.getGameStateService().deletePracticeAdmin(uuid);
+    }
+    
+    @Override
+    protected @NotNull Map<UUID, String> getAdminNames() throws SQLException {
+        return context.getGameStateService().getPracticeAdminNames();
     }
 }

--- a/src/main/java/org/braekpo1nt/mctmanager/games/gamestate/states/StorageUtilState.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/gamestate/states/StorageUtilState.java
@@ -1,10 +1,20 @@
 package org.braekpo1nt.mctmanager.games.gamestate.states;
 
+import org.braekpo1nt.mctmanager.Main;
+import org.braekpo1nt.mctmanager.database.entities.admin.ActiveAdminEntity;
 import org.braekpo1nt.mctmanager.games.gamestate.GameStateStorageUtil;
+import org.braekpo1nt.mctmanager.games.gamestate.MCTPlayerEntity;
+import org.braekpo1nt.mctmanager.games.gamestate.MCTTeamEntity;
 import org.jetbrains.annotations.NotNull;
 
 import java.sql.SQLException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.logging.Level;
 
 public abstract class StorageUtilState {
     
@@ -23,24 +33,140 @@ public abstract class StorageUtilState {
      * @param teamDisplayName the display name of the team
      * @param color the color string of the team
      * @return the score of the team (based on historical values)
-     * @throws SQLException if there is a database error
      */
-    public abstract int addTeam(String teamId, String teamDisplayName, String color) throws SQLException;
+    public CompletableFuture<Integer> addTeam(String teamId, String teamDisplayName, String color) {
+        MCTTeamEntity team = context.getGameState().addTeam(teamId, teamDisplayName, color);
+        return CompletableFuture.supplyAsync(() -> {
+                    try {
+                        int score = persistAddTeam(teamId, team);
+                        team.setScore(score);
+                        return score;
+                    } catch (SQLException e) {
+                        throw new CompletionException(e);
+                    }
+                }, context.getDatabaseExecutor())
+                .exceptionally(e -> {
+                    Main.logger().log(Level.SEVERE, String.format("unable to persist team with id %s", teamId), e);
+                    return 0;
+                });
+    }
     
-    public abstract void removeTeam(String teamId) throws SQLException;
+    protected abstract int persistAddTeam(String teamId, MCTTeamEntity team) throws SQLException;
+    
+    public CompletableFuture<Void> removeTeam(String teamId) {
+        List<UUID> uuidsOnTeam = context.getParticipantUUIDsOnTeam(teamId);
+        context.getGameState().removePlayers(uuidsOnTeam);
+        context.getGameState().removeTeam(teamId);
+        return CompletableFuture.runAsync(() -> {
+                    try {
+                        context.getGameStateService().deleteTeam(teamId);
+                        persistRemoveTeam(teamId);
+                    } catch (SQLException e) {
+                        Main.logger().log(Level.SEVERE, String.format("Unable to delete team with id %s", teamId));
+                        throw new CompletionException(e);
+                    }
+                }, context.getDatabaseExecutor())
+                .exceptionally(e -> {
+                    Main.logger().log(Level.SEVERE, String.format("unable to remove team with teamId %s", teamId), e);
+                    return null;
+                });
+    }
+    
+    protected abstract void persistRemoveTeam(String teamId) throws SQLException;
     
     /**
      * @param uuid the UUID of the player to join
      * @param ign the ign of the player to join
      * @param teamId the teamId to join them to
      * @return the score of the participant (based on historical values)
-     * @throws SQLException if there's a database error
      */
-    public abstract int addNewPlayer(@NotNull UUID uuid, @NotNull String ign, @NotNull String teamId) throws SQLException;
+    public CompletableFuture<Integer> joinPlayer(@NotNull UUID uuid, @NotNull String ign, @NotNull String teamId) {
+        MCTPlayerEntity player = context.getGameState().addPlayer(uuid, ign, teamId);
+        return CompletableFuture.supplyAsync(() -> {
+                    try {
+                        int score = persistJoinPlayer(uuid, player);
+                        player.setScore(score);
+                        return score;
+                    } catch (SQLException e) {
+                        throw new CompletionException(e);
+                    }
+                }, context.getDatabaseExecutor())
+                .exceptionally(e -> {
+                    Main.logger().log(Level.SEVERE, String.format("unable to persist player with UUID %s, ign %s, and teamId %s", uuid, ign, teamId), e);
+                    return 0;
+                });
+    }
     
-    public abstract void leavePlayer(UUID playerUniqueId) throws SQLException;
+    protected abstract int persistJoinPlayer(@NotNull UUID uuid, MCTPlayerEntity player) throws SQLException;
     
-    public abstract void addAdmin(UUID adminUniqueId) throws SQLException;
+    public CompletableFuture<Void> leavePlayer(@NotNull UUID uuid) {
+        context.getGameState().removePlayer(uuid);
+        return CompletableFuture.runAsync(() -> {
+                    try {
+                        String uuidString = uuid.toString();
+                        context.getGameStateService().deleteParticipant(uuidString);
+                        persistLeavePlayer(uuidString);
+                    } catch (SQLException e) {
+                        throw new CompletionException(e);
+                    }
+                }, context.getDatabaseExecutor())
+                .exceptionally(e -> {
+                    Main.logger().log(Level.SEVERE, String.format("unable to leave player with UUID %s", uuid), e);
+                    return null;
+                });
+    }
     
-    public abstract void removeAdmin(UUID adminUniqueId) throws SQLException;
+    public abstract void persistLeavePlayer(@NotNull String uuidString) throws SQLException;
+    
+    public CompletableFuture<Void> addAdmin(UUID uuid) {
+        context.getGameState().addAdmin(uuid);
+        return CompletableFuture.runAsync(() -> {
+                    try {
+                        String uuidString = uuid.toString();
+                        context.getGameStateService().addAdmin(new ActiveAdminEntity(uuidString));
+                        persistAddAdmin(uuidString);
+                    } catch (SQLException e) {
+                        throw new CompletionException(e);
+                    }
+                }, context.getDatabaseExecutor())
+                .exceptionally(e -> {
+                    Main.logger().log(Level.SEVERE, String.format("unable to add admin with UUID %s", uuid), e);
+                    return null;
+                });
+    }
+    
+    
+    public abstract void persistAddAdmin(@NotNull String uuid) throws SQLException;
+    
+    public CompletableFuture<Void> removeAdmin(UUID uuid) {
+        context.getGameState().removeAdmin(uuid);
+        return CompletableFuture.runAsync(() -> {
+                    try {
+                        String uuidString = uuid.toString();
+                        context.getGameStateService().deleteActiveAdmin(uuidString);
+                        persistRemoveAdmin(uuidString);
+                    } catch (SQLException e) {
+                        throw new CompletionException(e);
+                    }
+                }, context.getDatabaseExecutor())
+                .exceptionally(e -> {
+                    Main.logger().log(Level.SEVERE, String.format("unable to remove admin with UUID %s", uuid), e);
+                    return null;
+                });
+    }
+    
+    public abstract void persistRemoveAdmin(@NotNull String uuid) throws SQLException;
+    
+    public @NotNull CompletableFuture<Map<UUID, String>> getAllAdminNames() {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                return getAdminNames();
+            } catch (SQLException e) {
+                Main.logger().log(Level.SEVERE, "Unable get admin names from database", e);
+                return Collections.emptyMap();
+            }
+        }, context.getDatabaseExecutor());
+    }
+    
+    protected abstract @NotNull Map<UUID, String> getAdminNames() throws SQLException;
 }

--- a/src/main/java/org/braekpo1nt/mctmanager/games/utils/GameManagerUtils.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/utils/GameManagerUtils.java
@@ -48,6 +48,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 
 public class GameManagerUtils {
@@ -182,48 +183,56 @@ public class GameManagerUtils {
      * @param colorString the string representing the team's color
      * @return a comprehensive message about the success or failure of the addition of the given team
      */
-    public static CommandResult addTeam(GameManager gameManager, @NotNull String teamId, @NotNull String teamDisplayName, @NotNull String colorString) {
+    public static CompletableFuture<CommandResult> addTeam(GameManager gameManager, @NotNull String teamId, @NotNull String teamDisplayName, @NotNull String colorString) {
         Team existingTeam = gameManager.getTeam(teamId);
         if (existingTeam != null) {
             return CommandResult.failure(Component.text("A team already exists with the teamId \"")
-                    .append(Component.text(teamId))
-                    .append(Component.text("\"")));
+                            .append(Component.text(teamId))
+                            .append(Component.text("\"")))
+                    .asFuture();
         }
         if (teamId.equals(GameManager.ADMIN_TEAM)) {
             return CommandResult.failure(Component.empty()
-                    .append(Component.text(teamId)
-                            .decorate(TextDecoration.BOLD))
-                    .append(Component.text(" cannot be "))
-                    .append(Component.text(GameManager.ADMIN_TEAM)
-                            .decorate(TextDecoration.BOLD))
-                    .append(Component.text(" because that is reserved for the admin team.")));
+                            .append(Component.text(teamId)
+                                    .decorate(TextDecoration.BOLD))
+                            .append(Component.text(" cannot be "))
+                            .append(Component.text(GameManager.ADMIN_TEAM)
+                                    .decorate(TextDecoration.BOLD))
+                            .append(Component.text(" because that is reserved for the admin team.")))
+                    .asFuture();
         }
         if (!GameManagerUtils.validTeamId(teamId)) {
             return CommandResult.failure(Component.text("Provide a valid team name\n")
-                    .append(Component.text(
-                            "Allowed characters: -, +, ., _, A-Z, a-z, and 0-9")));
+                            .append(Component.text(
+                                    "Allowed characters: -, +, ., _, A-Z, a-z, and 0-9")))
+                    .asFuture();
         }
         
         if (teamDisplayName.isEmpty()) {
-            return CommandResult.failure("Display name can't be blank");
+            return CommandResult.failure("Display name can't be blank")
+                    .asFuture();
         }
         
         if (!ColorMap.hasNamedTextColor(colorString)) {
             return CommandResult.failure(Component.empty()
-                    .append(Component.text(colorString)
-                            .decorate(TextDecoration.BOLD))
-                    .append(Component.text(" is not a recognized color")));
+                            .append(Component.text(colorString)
+                                    .decorate(TextDecoration.BOLD))
+                            .append(Component.text(" is not a recognized color")))
+                    .asFuture();
         }
         
-        Team team = gameManager.addTeam(teamId, teamDisplayName, colorString);
-        if (team == null) {
-            return CommandResult.failure("Unable to create team (already exists)");
-        }
-        return CommandResult.success(Component.text("Created team ")
-                .append(team.getFormattedDisplayName())
-                .append(Component.text(" (teamId=\""))
-                .append(Component.text(teamId))
-                .append(Component.text("\")")));
+        return gameManager.addTeam(teamId, teamDisplayName, colorString)
+                .thenApply(team -> {
+                    if (team == null) {
+                        return CommandResult.failure("Unable to create team (already exists)");
+                    }
+                    return CommandResult.success(Component.text("Created team ")
+                            .append(team.getFormattedDisplayName())
+                            .append(Component.text(" (teamId=\""))
+                            .append(Component.text(teamId))
+                            .append(Component.text("\")")));
+                })
+                ;
     }
     
     /**
@@ -232,13 +241,14 @@ public class GameManagerUtils {
      * @param teamId the teamId of the team to remove. Must be a valid teamId.
      * @return a CommandResult detailing what happened.
      */
-    public static CommandResult removeTeam(@NotNull GameManager gameManager, @NotNull String teamId) {
+    public static CompletableFuture<CommandResult> removeTeam(@NotNull GameManager gameManager, @NotNull String teamId) {
         Team existingTeam = gameManager.getTeam(teamId);
         if (existingTeam == null) {
             return CommandResult.failure(Component.text("Team ")
-                    .append(Component.text(teamId)
-                            .decorate(TextDecoration.BOLD))
-                    .append(Component.text(" does not exist")));
+                            .append(Component.text(teamId)
+                                    .decorate(TextDecoration.BOLD))
+                            .append(Component.text(" does not exist")))
+                    .asFuture();
         }
         return gameManager.removeTeam(teamId);
     }
@@ -468,26 +478,35 @@ public class GameManagerUtils {
         private final String teamId;
     }
     
+    private static boolean presetApplyLock = false;
+    
     /**
      * @param opts the options
      * @return a comprehensive {@link CompositeCommandResult} including every {@link CommandResult} of the (perhaps
      * many) operations performed here.
+     * // TODO: this is architecturally sound, but very difficult to read. Improve readability.
      */
-    public static @NotNull CommandResult applyPreset(
+    public static @NotNull CompletableFuture<CommandResult> applyPreset(
             @NotNull Main plugin,
             @NotNull GameManager gameManager,
             @NotNull PresetStorageUtil storageUtil,
             @NotNull File presetFile,
             @NotNull CommandSender sender,
             @NotNull PresetOpts opts) {
+        if (presetApplyLock) {
+            return CommandResult.failure("A preset is currently being applied, please wait for its completion.").asFuture();
+        }
+        presetApplyLock = true;
         Preset preset;
         try {
             preset = storageUtil.loadPreset(presetFile);
         } catch (ConfigException e) {
             Main.logger().log(Level.SEVERE, String.format("Could not load preset. %s", e.getMessage()), e);
+            presetApplyLock = false;
             return CommandResult.failure(Component.empty()
-                    .append(Component.text("Error occurred loading preset. See console for details: "))
-                    .append(Component.text(e.getMessage())));
+                            .append(Component.text("Error occurred loading preset. See console for details: "))
+                            .append(Component.text(e.getMessage())))
+                    .asFuture();
         }
         
         
@@ -508,79 +527,96 @@ public class GameManagerUtils {
         }
         
         // check if they want to overwrite or merge the game state
+        CompletableFuture<List<CommandResult>> chain = CompletableFuture.completedFuture(results);
         if (opts.override()) {
-            Main.logf("Overriding with preset");
             // remove all existing teams and leave all existing players
             int oldParticipantCount = offlineParticipants.size();
             Set<String> teamIds = gameManager.getTeamIds();
             int oldTeamCount = teamIds.size();
             for (String teamId : teamIds) {
-                Main.logf("attempting to remove team %s", teamId);
-                results.add(removeTeam(gameManager, teamId));
+                chain = chain.thenComposeAsync(commandResults -> {
+                    CompletableFuture<CommandResult> joinFuture = removeTeam(gameManager, teamId);
+                    return joinFuture.thenApply(result -> {
+                        commandResults.add(result);
+                        return commandResults;
+                    });
+                }, plugin.getMainThreadExecutor());
             }
-            results.add(CommandResult.success(Component.empty()
-                    .append(Component.text("Removed "))
-                    .append(Component.text(oldTeamCount))
-                    .append(Component.text(" team(s) and left "))
-                    .append(Component.text(oldParticipantCount))
-                    .append(Component.text(" participants"))));
+            chain = chain.thenApply(commandResults -> {
+                        commandResults.add(CommandResult.success(Component.empty()
+                                .append(Component.text("Removed "))
+                                .append(Component.text(oldTeamCount))
+                                .append(Component.text(" team(s) and left "))
+                                .append(Component.text(oldParticipantCount))
+                                .append(Component.text(" participants"))));
+                        return commandResults;
+                    }
+            );
         }
-        
+        chain = chain.exceptionally(e -> List.of(CommandResult.throwable("remove the teams", e)));
         // add all the teams
         int teamCount = preset.getTeamCount();
         int participantCount = preset.getParticipantCount();
         for (Preset.PresetTeam team : preset.getTeams()) {
-            Team realTeam = gameManager.getTeam(team.getTeamId());
-            if (realTeam != null) {
-                results.add(CommandResult.success(Component.empty()
-                        .append(realTeam.getFormattedDisplayName())
-                        .append(Component.text(" already exists."))
-                ));
-            } else {
-                CommandResult commandResult = addTeam(gameManager, team.getTeamId(), team.getDisplayName(), team.getColor());
-                results.add(commandResult);
-            }
+            chain = chain.thenComposeAsync(commandResults -> {
+                Team realTeam = gameManager.getTeam(team.getTeamId());
+                if (realTeam != null) {
+                    commandResults.add(CommandResult.success(Component.empty()
+                            .append(realTeam.getFormattedDisplayName())
+                            .append(Component.text(" already exists."))
+                    ));
+                    return CompletableFuture.completedFuture(commandResults);
+                } else {
+                    CompletableFuture<CommandResult> joinFuture = addTeam(gameManager, team.getTeamId(), team.getDisplayName(), team.getColor());
+                    return joinFuture.thenApply(result -> {
+                        commandResults.add(result);
+                        return commandResults;
+                    });
+                }
+            }, plugin.getMainThreadExecutor());
         }
-        
-        List<ParticipantInfo> participantInfos = new ArrayList<>(participantCount);
-        for (Preset.PresetTeam team : preset.getTeams()) {
-            for (Preset.PresetParticipant member : team.getMembers()) {
-                participantInfos.add(new ParticipantInfo(
-                        member.getUuid(),
-                        member.getIgn(),
-                        team.getTeamId()
-                ));
+        chain = chain.exceptionally(e -> List.of(CommandResult.throwable("create the teams", e)));
+        return chain.thenApplyAsync(v -> {
+            List<ParticipantInfo> participantInfos = new ArrayList<>(participantCount);
+            for (Preset.PresetTeam team : preset.getTeams()) {
+                for (Preset.PresetParticipant member : team.getMembers()) {
+                    participantInfos.add(new ParticipantInfo(
+                            member.getUuid(),
+                            member.getIgn(),
+                            team.getTeamId()
+                    ));
+                }
             }
-        }
-        
-        results.add(CommandResult.success(Component.empty()
-                .append(Component.text("Successfully added "))
-                .append(Component.text(teamCount))
-                .append(Component.text(" team(s)")))
-        );
-        
-        // join all the participants in a staggered formation to prevent crashes
-        results.add(CommandResult.success(Component.empty()
-                .append(Component.text(participantCount))
-                .append(Component.text(" participants to join. "))
-                .append(Component.text(DELAY_BETWEEN_CYCLE_IN_SECONDS))
-                .append(Component.text(" second delay before first wave of "))
-                .append(Component.text(Math.min(NUM_OF_PARTICIPANTS_PER_CYCLE, participantCount)))
-                .append(Component.text(" participants."))
-        ));
-        plugin.getServer().getScheduler().runTaskLater(plugin, () -> {
-            bulkJoinParticipants(
-                    participantInfos,
-                    plugin,
-                    gameManager,
-                    sender,
-                    opts,
-                    0,
-                    preset.getTeams()
+            
+            results.add(CommandResult.success(Component.empty()
+                    .append(Component.text("Successfully added "))
+                    .append(Component.text(teamCount))
+                    .append(Component.text(" team(s)")))
             );
-        }, 20 * DELAY_BETWEEN_CYCLE_IN_SECONDS);
-        
-        return CompositeCommandResult.all(results);
+            
+            // join all the participants in a staggered formation to prevent crashes
+            results.add(CommandResult.success(Component.empty()
+                    .append(Component.text(participantCount))
+                    .append(Component.text(" participants to join. "))
+                    .append(Component.text(DELAY_BETWEEN_CYCLE_IN_SECONDS))
+                    .append(Component.text(" second delay before first wave of "))
+                    .append(Component.text(Math.min(NUM_OF_PARTICIPANTS_PER_CYCLE, participantCount)))
+                    .append(Component.text(" participants."))
+            ));
+            plugin.getServer().getScheduler().runTaskLater(plugin, () -> {
+                bulkJoinParticipants(
+                        participantInfos,
+                        plugin,
+                        gameManager,
+                        sender,
+                        opts,
+                        0,
+                        preset.getTeams()
+                );
+            }, 20 * DELAY_BETWEEN_CYCLE_IN_SECONDS);
+            
+            return CompositeCommandResult.all(results);
+        }, plugin.getMainThreadExecutor());
     }
     
     /**
@@ -605,43 +641,55 @@ public class GameManagerUtils {
                     teams,
                     participantInfos.size()
             );
+            presetApplyLock = false;
             return;
         }
-        List<CommandResult> results = new ArrayList<>();
+        CompletableFuture<List<CommandResult>> chain = CompletableFuture.completedFuture(new ArrayList<>());
         // join the first 5 participants
         int maxIndex = Math.min(startIndex + NUM_OF_PARTICIPANTS_PER_CYCLE, participantInfos.size());
         int left = participantInfos.size() - maxIndex;
         for (int i = startIndex; i < maxIndex; i++) {
             ParticipantInfo participantInfo = participantInfos.get(i);
-            Player player = plugin.getServer().getPlayer(participantInfo.getUuid());
-            if (player != null) {
-                // they are online
-                results.add(gameManager.joinOnlineParticipant(player, participantInfo.getTeamId()));
-            } else {
-                // they are not online
-                results.add(gameManager.joinOfflineParticipant(participantInfo.getUuid(), participantInfo.getIgn(), participantInfo.getTeamId()));
-            }
+            chain = chain.thenComposeAsync(results -> {
+                CompletableFuture<CommandResult> joinFuture;
+                Player player = plugin.getServer().getPlayer(participantInfo.getUuid());
+                if (player != null) {
+                    // they are online
+                    joinFuture = gameManager.joinOnlineParticipant(player, participantInfo.getTeamId());
+                } else {
+                    // they are not online
+                    joinFuture = gameManager.joinOfflineParticipant(participantInfo.getUuid(), participantInfo.getIgn(), participantInfo.getTeamId());
+                }
+                return joinFuture.thenApply(result -> {
+                    results.add(result);
+                    return results;
+                });
+            }, plugin.getMainThreadExecutor());
         }
-        if (left > 0) {
-            results.add(CommandResult.success(Component.empty()
-                    .append(Component.text(left))
-                    .append(Component.text(" participants to go. "))
-                    .append(Component.text(DELAY_BETWEEN_CYCLE_IN_SECONDS))
-                    .append(Component.text(" second delay before next wave of "))
-                    .append(Component.text(Math.min(NUM_OF_PARTICIPANTS_PER_CYCLE, left)))
-                    .append(Component.text(" participants."))
-            ));
-        } else {
-            results.add(CommandResult.success(Component.empty()
-                    .append(Component.text("All "))
-                    .append(Component.text(participantInfos.size()))
-                    .append(Component.text(" participants joined. "))
-                    .append(Component.text(DELAY_BETWEEN_CYCLE_IN_SECONDS))
-                    .append(Component.text(" second delay before final preset options are applied."))
-            ));
-        }
-        CommandResult result = CompositeCommandResult.all(results);
-        CommandResult.showResult(sender, result);
+        chain.thenApply(results -> {
+                    if (left > 0) {
+                        results.add(CommandResult.success(Component.empty()
+                                .append(Component.text(left))
+                                .append(Component.text(" participants to go. "))
+                                .append(Component.text(DELAY_BETWEEN_CYCLE_IN_SECONDS))
+                                .append(Component.text(" second delay before next wave of "))
+                                .append(Component.text(Math.min(NUM_OF_PARTICIPANTS_PER_CYCLE, left)))
+                                .append(Component.text(" participants."))
+                        ));
+                    } else {
+                        results.add(CommandResult.success(Component.empty()
+                                .append(Component.text("All "))
+                                .append(Component.text(participantInfos.size()))
+                                .append(Component.text(" participants joined. "))
+                                .append(Component.text(DELAY_BETWEEN_CYCLE_IN_SECONDS))
+                                .append(Component.text(" second delay before final preset options are applied."))
+                        ));
+                    }
+                    return results;
+                })
+                .thenAccept(results -> {
+                    CommandResult.showResult(sender, CompositeCommandResult.all(results));
+                });
         plugin.getServer().getScheduler().runTaskLater(plugin, () -> {
             bulkJoinParticipants(
                     participantInfos,

--- a/src/main/java/org/braekpo1nt/mctmanager/hub/config/HubConfig.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/hub/config/HubConfig.java
@@ -49,10 +49,6 @@ public class HubConfig {
          * The allowed games to play during practice  mode
          */
         private List<GameInfo> allowedGames;
-        /**
-         * If null, no preset will be used.
-         */
-        private @Nullable PresetConfig preset;
     }
     
     @Data

--- a/src/main/java/org/braekpo1nt/mctmanager/hub/config/HubConfigController.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/hub/config/HubConfigController.java
@@ -79,7 +79,6 @@ public class HubConfigController extends ConfigController<HubConfigDTO> {
                 HubConfigDTO.PracticeDTO.builder()
                         .restrictGameJoining(false)
                         .allowedGames(Collections.emptyList())
-                        .preset(null)
                         .build(),
                 Collections.emptyList(),
                 Collections.emptyList(),

--- a/src/main/java/org/braekpo1nt/mctmanager/hub/config/HubConfigDTO.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/hub/config/HubConfigDTO.java
@@ -12,7 +12,6 @@ import org.braekpo1nt.mctmanager.config.validation.Validatable;
 import org.braekpo1nt.mctmanager.config.validation.Validator;
 import org.braekpo1nt.mctmanager.games.game.enums.GameType;
 import org.braekpo1nt.mctmanager.games.gamemanager.GameInstanceId;
-import org.braekpo1nt.mctmanager.games.gamestate.preset.PresetDTO;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -29,7 +28,7 @@ import java.util.stream.Collectors;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-class HubConfigDTO implements Validatable {
+public class HubConfigDTO implements Validatable {
     
     private String version;
     private String world;
@@ -96,7 +95,6 @@ class HubConfigDTO implements Validatable {
          */
         private Boolean restrictGameJoining;
         private List<GameInfoDTO> allowedGames;
-        private @Nullable PresetDTO.PresetConfigDTO preset;
         
         @Override
         public void validate(@NotNull Validator validator) {
@@ -108,9 +106,6 @@ class HubConfigDTO implements Validatable {
                 validator.validate(!usedIds.contains(id), "allowedGames has duplicate game/config combo: \"%s\" and \"%s\"", id.getGameType(), id.getConfigFile());
                 usedIds.add(id);
             }
-            if (preset != null) {
-                preset.validate(validator.path("preset"));
-            }
         }
         
         public HubConfig.PracticeConfig toPractice() {
@@ -121,7 +116,6 @@ class HubConfigDTO implements Validatable {
                             .map(HubConfig.GameInfo::getId)
                             .collect(Collectors.toSet()))
                     .allowedGames(games)
-                    .preset(preset != null ? preset.toPreset() : null)
                     .build();
         }
         

--- a/src/main/java/org/braekpo1nt/mctmanager/ui/tablist/TabList.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/ui/tablist/TabList.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 
 public class TabList implements UIManager {
@@ -238,76 +239,61 @@ public class TabList implements UIManager {
     }
     
     /**
-     * This is so that tests can skip the scheduling and just perform the action
-     * @param runnable the action to perform
-     */
-    protected void scheduleAsync(Runnable runnable) {
-        plugin.getServer().getScheduler().runTaskAsynchronously(plugin, runnable);
-    }
-    
-    /**
-     * This is so that tests can skip the scheduling and just perform the action
-     * @param runnable the action to perform
-     */
-    protected void scheduleSync(Runnable runnable) {
-        plugin.getServer().getScheduler().runTask(plugin, runnable);
-    }
-    
-    /**
      * Updates all views to reflect the current state of the data.
+     * @return a future containing the TabList generation code in async, and the visual updates
+     * on the main thread
      */
-    private void update() {
+    private CompletableFuture<Void> update() {
         if (!plugin.isEnabled()) {
-            return;
+            return CompletableFuture.completedFuture(null);
         }
-        scheduleAsync(() -> {
-            Component tabList = toTabList();
-            scheduleSync(() -> {
-                for (PlayerData playerData : playerDatas.values()) {
-                    playerData.getPlayer().sendPlayerListHeader(tabList);
-                }
-            });
-        });
+        return CompletableFuture.supplyAsync(this::toTabList, plugin.getDatabaseExecutor())
+                .thenAcceptAsync(tabList -> {
+                    for (PlayerData playerData : playerDatas.values()) {
+                        playerData.getPlayer().sendPlayerListHeader(tabList);
+                    }
+                }, plugin.getMainThreadExecutor());
     }
     
     /**
      * Updates the view to reflect the current state of the data for just
      * the given playerData
      * @param playerData the playerData to update the view of
+     * @return a future containing the TabList generation code in async, and the visual updates
+     * on the main thread
      */
-    private void update(PlayerData playerData) {
+    private CompletableFuture<Void> update(PlayerData playerData) {
         if (!plugin.isEnabled()) {
-            return;
+            return CompletableFuture.completedFuture(null);
         }
         if (playerData.isVisible()) {
-            scheduleAsync(() -> {
-                Component tabList = toTabList();
-                scheduleSync(() -> {
-                    playerData.getPlayer().sendPlayerListHeader(tabList);
-                });
-            });
+            return CompletableFuture.supplyAsync(this::toTabList, plugin.getDatabaseExecutor())
+                    .thenAcceptAsync(tabList -> {
+                        playerData.getPlayer().sendPlayerListHeader(tabList);
+                    }, plugin.getMainThreadExecutor());
         } else {
             playerData.getPlayer().sendPlayerListHeader(Component.empty());
+            return CompletableFuture.completedFuture(null);
         }
     }
     
-    public void addTeam(@NotNull String teamId, @NotNull String displayName, @NotNull TextColor color) {
+    public CompletableFuture<Void> addTeam(@NotNull String teamId, @NotNull String displayName, @NotNull TextColor color) {
         if (teamDatas.containsKey(teamId)) {
             logUIError("Team with teamId \"%s\" already exists in this TabList", teamId);
-            return;
+            return CompletableFuture.completedFuture(null);
         }
         TeamData teamData = new TeamData(color, displayName, new ArrayList<>(), 0);
         teamDatas.put(teamId, teamData);
-        update();
+        return update();
     }
     
-    public void removeTeam(@NotNull String teamId) {
+    public CompletableFuture<Void> removeTeam(@NotNull String teamId) {
         TeamData teamData = teamDatas.remove(teamId);
         if (teamData == null) {
             logUIError("Team with teamId \"%s\" does not exist in this TabList", teamId);
-            return;
+            return CompletableFuture.completedFuture(null);
         }
-        update();
+        return update();
     }
     
     /**
@@ -315,13 +301,13 @@ public class TabList implements UIManager {
      * @param teamId the teamId to update the score of. Must be a valid teamId in this TabList.
      * @param score the score to update to.
      */
-    public void setScore(@NotNull String teamId, int score) {
+    public CompletableFuture<Void> setScore(@NotNull String teamId, int score) {
         TeamData teamData = getTeamData(teamId);
         if (teamData == null) {
-            return;
+            return CompletableFuture.completedFuture(null);
         }
         teamData.setScore(score);
-        update();
+        return update();
     }
     
     /**
@@ -329,9 +315,9 @@ public class TabList implements UIManager {
      * @param teamIdsToScores the teamIds to update mapped to their new scores.
      * (Any teamIds not in this TabList will be ignored)
      */
-    public void setScores(@NotNull Map<@NotNull String, @NotNull Integer> teamIdsToScores) {
+    public CompletableFuture<Void> setScores(@NotNull Map<@NotNull String, @NotNull Integer> teamIdsToScores) {
         if (teamIdsToScores.isEmpty()) {
-            return;
+            return CompletableFuture.completedFuture(null);
         }
         for (Map.Entry<String, Integer> entry : teamIdsToScores.entrySet()) {
             String teamId = entry.getKey();
@@ -341,7 +327,7 @@ public class TabList implements UIManager {
                 teamData.setScore(score);
             }
         }
-        update();
+        return update();
     }
     
     /**
@@ -350,9 +336,9 @@ public class TabList implements UIManager {
      * (Any teams not in this TabList will be ignored.)
      * @param <T> any implementation of {@link Team}
      */
-    public <T extends Team> void setScores(Collection<T> teams) {
+    public <T extends Team> CompletableFuture<Void> setScores(Collection<T> teams) {
         if (teams.isEmpty()) {
-            return;
+            return CompletableFuture.completedFuture(null);
         }
         for (T team : teams) {
             TeamData teamData = getTeamData(team.getTeamId());
@@ -360,7 +346,7 @@ public class TabList implements UIManager {
                 teamData.setScore(team.getScore());
             }
         }
-        update();
+        return update();
     }
     
     /**
@@ -374,35 +360,35 @@ public class TabList implements UIManager {
      * @param teamId the team to join the participant to
      * @param grey whether the participant's name should be grey, or the color of their team
      */
-    public void joinParticipant(@NotNull ParticipantID pid, @NotNull String name, @NotNull String teamId, boolean grey) {
+    public CompletableFuture<Void> joinParticipant(@NotNull ParticipantID pid, @NotNull String name, @NotNull String teamId, boolean grey) {
         ParticipantData existingParticipantData = participantDatas.get(pid);
         if (existingParticipantData != null) {
             logUIError("Participant with UUID \"%s\" and name \"%s\" is already contained in this TabList, joined to team with id \"%s\"", pid, existingParticipantData.getName(), existingParticipantData.getTeamId());
-            return;
+            return CompletableFuture.completedFuture(null);
         }
         TeamData teamData = getTeamData(teamId);
         if (teamData == null) {
-            return;
+            return CompletableFuture.completedFuture(null);
         }
         ParticipantData newParticipantData = new ParticipantData(name, teamId, grey);
         teamData.getParticipants().add(newParticipantData);
         participantDatas.put(pid, newParticipantData);
-        update();
+        return update();
     }
     
     /**
      * Leave the given participant from their team
      * @param pid the UUID of the participant to leave. Must be a valid UUID contained in this TabList.
      */
-    public void leaveParticipant(@NotNull ParticipantID pid) {
+    public CompletableFuture<Void> leaveParticipant(@NotNull ParticipantID pid) {
         ParticipantData participantData = participantDatas.remove(pid);
         if (participantData == null) {
             logUIError("Participant with UUID \"%s\" is not contained in this TabList", pid);
-            return;
+            return CompletableFuture.completedFuture(null);
         }
         TeamData teamData = teamDatas.get(participantData.getTeamId());
         teamData.getParticipants().remove(participantData);
-        update();
+        return update();
     }
     
     /**
@@ -419,13 +405,13 @@ public class TabList implements UIManager {
      * @param pid the participant id of the {@link ParticipantData}
      * @param grey true makes the player name grey, false makes it their team color
      */
-    public void setParticipantGrey(@NotNull ParticipantID pid, boolean grey) {
+    public CompletableFuture<Void> setParticipantGrey(@NotNull ParticipantID pid, boolean grey) {
         ParticipantData participantData = getParticipantData(pid);
         if (participantData == null) {
-            return;
+            return CompletableFuture.completedFuture(null);
         }
         participantData.setGrey(grey);
-        update();
+        return update();
     }
     
     /**
@@ -435,14 +421,14 @@ public class TabList implements UIManager {
      * TabList they will be ignored.
      * @param grey true makes the player names grey, false makes them their team colors
      */
-    public void setParticipantGreys(@NotNull Collection<? extends Participant> participants, boolean grey) {
+    public CompletableFuture<Void> setParticipantGreys(@NotNull Collection<? extends Participant> participants, boolean grey) {
         for (Participant participant : participants) {
             ParticipantData participantData = getParticipantData(participant.getParticipantID());
             if (participantData != null) {
                 participantData.setGrey(grey);
             }
         }
-        update();
+        return update();
     }
     
     /**
@@ -467,14 +453,15 @@ public class TabList implements UIManager {
      * players who are viewers of this TabList.
      * @param uuid the UUID of the player to set the visibility of. Must be the UUID of a player viewing this TabList
      * @param visible true if the player should see the content, false otherwise.
+     * @return a future containing the visual update code
      */
-    public void setVisibility(@NotNull UUID uuid, boolean visible) {
+    public CompletableFuture<Void> setVisibility(@NotNull UUID uuid, boolean visible) {
         PlayerData playerData = getPlayerData(uuid);
         if (playerData == null) {
-            return;
+            return CompletableFuture.completedFuture(null);
         }
         playerData.setVisible(visible);
-        update(playerData);
+        return update(playerData);
     }
     
     /**

--- a/src/test/java/org/braekpo1nt/mctmanager/MockMain.java
+++ b/src/test/java/org/braekpo1nt/mctmanager/MockMain.java
@@ -4,6 +4,7 @@ import com.github.retrooper.packetevents.PacketEvents;
 import com.mojang.brigadier.arguments.ArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import org.braekpo1nt.mctmanager.database.Database;
+import org.braekpo1nt.mctmanager.database.ImmediateExecutorService;
 import org.braekpo1nt.mctmanager.database.service.GameStateService;
 import org.braekpo1nt.mctmanager.games.gamemanager.GameManager;
 import org.braekpo1nt.mctmanager.games.gamemanager.MockGameManager;
@@ -12,11 +13,15 @@ import org.braekpo1nt.mctmanager.hub.config.HubConfig;
 import org.braekpo1nt.mctmanager.listeners.BlockEffectsListener;
 import org.braekpo1nt.mctmanager.packetevents.PacketEventsAPIMock;
 import org.braekpo1nt.mctmanager.ui.sidebar.MockSidebarFactory;
+import org.bukkit.Server;
 import org.bukkit.scoreboard.Scoreboard;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
 import java.sql.SQLException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.logging.Level;
 
 public class MockMain extends Main {
@@ -47,13 +52,29 @@ public class MockMain extends Main {
                 new MockSidebarFactory(),
                 config,
                 database,
-                gameStateService
+                gameStateService,
+                Runnable::run
         );
     }
     
     @Override
     protected String getMigrationLocation() {
         return "classpath:db/migration/test";
+    }
+    
+    @Override
+    protected @NotNull ExecutorService createDatabaseExecutor() {
+        // the tests shouldn't use a threaded executor service
+        // Cast the server to the MyCustomServerMock implementation so that you can mark non-thread-safe operations
+        if (!(getServer() instanceof MyCustomServerMock server)) {
+            throw new IllegalStateException("MockMain requires an implementation of MyCustomServerMock to function properly. Use MockBukkit.mock(new MyCustomServerMock()) instead of another Server implementation.");
+        }
+        return new ImmediateExecutorService(server);
+    }
+    
+    @Override
+    protected @NotNull Executor createMainThreadExecutor() {
+        return Runnable::run;
     }
     
     @Override
@@ -65,7 +86,9 @@ public class MockMain extends Main {
         String jdbcUrl = "jdbc:sqlite:" + sqlitePath;
         flywayMigration(jdbcUrl, user, password, "", "", baselineOnMigrate);
         
-        return new Database(sqlitePath);
+        // Use a basic executor so that tests will run sequentially, rather than relying on unpredictable
+        // threads and asynchronous timing
+        return new Database(sqlitePath, Runnable::run);
     }
     
     @Override

--- a/src/test/java/org/braekpo1nt/mctmanager/MyCustomServerMock.java
+++ b/src/test/java/org/braekpo1nt/mctmanager/MyCustomServerMock.java
@@ -1,5 +1,7 @@
 package org.braekpo1nt.mctmanager;
 
+import lombok.Getter;
+import lombok.Setter;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Material;
@@ -33,6 +35,27 @@ import static org.mockito.Mockito.when;
  * - Create an initial test world called "TestWorld" which is used in many tests
  */
 public class MyCustomServerMock extends ServerMock {
+    
+    /**
+     * This is set to false by
+     * {@link org.braekpo1nt.mctmanager.database.ImmediateExecutorService#execute(Runnable)}
+     * so that {@link #isPrimaryThread()} returns false during fake "async" operations.
+     * True if world-modifying bukkit operations are allowed, false otherwise.
+     */
+    @Getter
+    @Setter
+    private boolean bukkitOperationIsAllowed = true;
+    
+    /**
+     * This will be false when run inside a {@link Runnable} operation in
+     * {@link org.braekpo1nt.mctmanager.database.ImmediateExecutorService#execute(Runnable)},
+     * so that non-bukkit safe operations throw an error.
+     * Also throws errors when we are truly off the main thread.
+     */
+    @Override
+    public boolean isPrimaryThread() {
+        return bukkitOperationIsAllowed && this.isOnMainThread();
+    }
     
     @Override
     public World getWorld(String name) {

--- a/src/test/java/org/braekpo1nt/mctmanager/TestUtils.java
+++ b/src/test/java/org/braekpo1nt/mctmanager/TestUtils.java
@@ -12,6 +12,8 @@ import net.kyori.adventure.text.ScoreComponent;
 import net.kyori.adventure.text.SelectorComponent;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.TranslatableComponent;
+import org.braekpo1nt.mctmanager.commands.manager.commandresult.CommandResult;
+import org.braekpo1nt.mctmanager.commands.manager.commandresult.FailureCommandResult;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Assertions;
@@ -27,6 +29,9 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestUtils {
     
@@ -130,5 +135,19 @@ public class TestUtils {
         } catch (IOException e) {
             e.printStackTrace();
         }
+    }
+    
+    public static void futureIsNotType(CompletableFuture<CommandResult> future, Class<?> type) {
+        assertThat(future).isNotCompletedExceptionally();
+        assertThat(future.join()).isNotInstanceOf(type);
+    }
+    
+    public static void futureIsNotFailure(CompletableFuture<CommandResult> future) {
+        futureIsNotType(future, FailureCommandResult.class);
+    }
+    
+    public static <T> void futureIsNotNull(CompletableFuture<T> future) {
+        assertThat(future).isNotCompletedExceptionally();
+        assertThat(future.join()).isNotNull();
     }
 }

--- a/src/test/java/org/braekpo1nt/mctmanager/commands/MCTCommandTest.java
+++ b/src/test/java/org/braekpo1nt/mctmanager/commands/MCTCommandTest.java
@@ -2,6 +2,7 @@ package org.braekpo1nt.mctmanager.commands;
 
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
+import org.braekpo1nt.mctmanager.Main;
 import org.braekpo1nt.mctmanager.MockMain;
 import org.braekpo1nt.mctmanager.MyCustomServerMock;
 import org.braekpo1nt.mctmanager.commands.mct.MCTCommand;
@@ -39,6 +40,7 @@ class MCTCommandTest {
             ex.printStackTrace();
             System.exit(1);
         }
+        Main.logger().setLevel(Level.SEVERE);
         gameManager = plugin.getGameManager();
         command = plugin.getCommand("mct");
     }

--- a/src/test/java/org/braekpo1nt/mctmanager/database/ImmediateExecutorService.java
+++ b/src/test/java/org/braekpo1nt/mctmanager/database/ImmediateExecutorService.java
@@ -1,0 +1,80 @@
+package org.braekpo1nt.mctmanager.database;
+
+import org.braekpo1nt.mctmanager.MyCustomServerMock;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * This is used for tests so that {@link java.util.concurrent.CompletableFuture}s which use
+ * async threads in production can instead be run directly sequentially and immediately
+ * on the main thread in tests. This reduces variability in tests and allows you
+ * to test functionality instead of testing timing.<br>
+ * This also toggles the {@link MyCustomServerMock#isBukkitOperationIsAllowed()} flag when running
+ * fake async operations so that thread checks fail. See {@link #execute(Runnable)} for more details.
+ */
+public class ImmediateExecutorService extends AbstractExecutorService {
+    
+    /**
+     * the server which contains {@link MyCustomServerMock#isBukkitOperationIsAllowed()} flag so
+     * that we can toggle it to false, run an "async" operation that isn't truly async for tests,
+     * then toggle it back to true for the successive operations.
+     */
+    private final MyCustomServerMock server;
+    private volatile boolean shutdown;
+    
+    /**
+     * @param server the server which contains {@link MyCustomServerMock#isBukkitOperationIsAllowed()}
+     * flag so that we can toggle it to false, run an "async" operation that isn't truly async
+     * for tests, then toggle it back to true for the successive operations.
+     */
+    public ImmediateExecutorService(@NotNull MyCustomServerMock server) {
+        this.server = server;
+    }
+    
+    @Override
+    public void shutdown() {
+        shutdown = true;
+    }
+    
+    @NotNull
+    @Override
+    public List<Runnable> shutdownNow() {
+        shutdown = true;
+        return Collections.emptyList();
+    }
+    
+    @Override
+    public boolean isShutdown() {
+        return shutdown;
+    }
+    
+    @Override
+    public boolean isTerminated() {
+        return shutdown;
+    }
+    
+    @Override
+    public boolean awaitTermination(long timeout, @NotNull TimeUnit unit) throws InterruptedException {
+        return true;
+    }
+    
+    /**
+     * Sets {@link MyCustomServerMock#isBukkitOperationIsAllowed()} to {@code false},
+     * runs the command,
+     * then sets {@link MyCustomServerMock#setBukkitOperationIsAllowed(boolean)} to {@code true} again.<br>
+     * This allows {@link MyCustomServerMock#isPrimaryThread()} to return {@code false} when
+     * {@link org.mockbukkit.mockbukkit.AsyncCatcher#catchOp(String)} is run, thus throwing
+     * an async exception when non-bukkit-safe operations are run.
+     * @param command the runnable task
+     */
+    @Override
+    public void execute(@NotNull Runnable command) {
+        server.setBukkitOperationIsAllowed(false);
+        command.run();
+        server.setBukkitOperationIsAllowed(true);
+    }
+}

--- a/src/test/java/org/braekpo1nt/mctmanager/database/service/GameStateServiceTest.java
+++ b/src/test/java/org/braekpo1nt/mctmanager/database/service/GameStateServiceTest.java
@@ -57,7 +57,7 @@ class GameStateServiceTest {
     void setup() throws SQLException, IOException {
         dbPath = Files.createTempFile("test-db-", "mctmanager.db");
         String sqlitePath = dbPath.toAbsolutePath().toString();
-        database = new Database(sqlitePath);
+        database = new Database(sqlitePath, Runnable::run);
         
         Logger logger = Logger.getLogger("test");
         logger.setLevel(Level.OFF);
@@ -740,7 +740,7 @@ class GameStateServiceTest {
     // rebuild tests start
     @Test
     void rebuildMaintenanceEmpty() throws SQLException {
-        gameStateService.rebuildMaintenanceMode();
+        assertThat(gameStateService.rebuildMaintenanceMode()).isNotCompletedExceptionally();
         assertThat(gameStateService.getActiveParticipants()).isEmpty();
         assertThat(gameStateService.getActiveTeams()).isEmpty();
         assertThat(gameStateService.getActiveAdmins()).isEmpty();
@@ -762,7 +762,7 @@ class GameStateServiceTest {
                 .participantUUID(uuid)
                 .teamId(teamId)
                 .build(), ign);
-        gameStateService.rebuildMaintenanceMode();
+        assertThat(gameStateService.rebuildMaintenanceMode()).isNotCompletedExceptionally();
         assertThat(gameStateService.getActiveParticipants()).hasSize(1);
         assertThat(gameStateService.getActiveTeams()).hasSize(1);
         assertThat(gameStateService.getActiveAdmins()).isEmpty();
@@ -819,7 +819,7 @@ class GameStateServiceTest {
                 .createdAt(new Date())
                 .build());
         AssertionsForClassTypes.assertThat(scoreEventEntity).isNotNull();
-        gameStateService.rebuildMaintenanceMode();
+        assertThat(gameStateService.rebuildMaintenanceMode()).isNotCompletedExceptionally();
         List<ActiveParticipant> activeParticipants = gameStateService.getActiveParticipants();
         assertThat(activeParticipants).hasSize(1);
         assertThat(activeParticipants.getFirst().getScore())

--- a/src/test/java/org/braekpo1nt/mctmanager/database/service/ScoreServiceTest.java
+++ b/src/test/java/org/braekpo1nt/mctmanager/database/service/ScoreServiceTest.java
@@ -24,7 +24,7 @@ class ScoreServiceTest {
     void setup() throws SQLException, IOException {
         dbPath = Files.createTempFile("test-db-", "mctmanager.db");
         String sqlitePath = dbPath.toAbsolutePath().toString();
-        database = new Database(sqlitePath);
+        database = new Database(sqlitePath, Runnable::run);
         
         Logger logger = Logger.getLogger("test");
         logger.setLevel(Level.OFF);

--- a/src/test/java/org/braekpo1nt/mctmanager/games/game/capturetheflag/CaptureTheFlagGameTest.java
+++ b/src/test/java/org/braekpo1nt/mctmanager/games/game/capturetheflag/CaptureTheFlagGameTest.java
@@ -41,6 +41,7 @@ public class CaptureTheFlagGameTest {
             Main.logger().log(Level.SEVERE, "UnimplementedOperationException from MockBukkit", ex);
             System.exit(1);
         }
+        Main.logger().setLevel(Level.SEVERE);
         gameManager = plugin.getGameManager();
         InputStream inputStream = CaptureTheFlagConfigController.class.getResourceAsStream("exampleCaptureTheFlagConfig.json");
         File configFolder = new File(plugin.getDataFolder(), GameType.CAPTURE_THE_FLAG.getId());

--- a/src/test/java/org/braekpo1nt/mctmanager/games/game/capturetheflag/config/CaptureTheFlagControllerTest.java
+++ b/src/test/java/org/braekpo1nt/mctmanager/games/game/capturetheflag/config/CaptureTheFlagControllerTest.java
@@ -31,6 +31,7 @@ class CaptureTheFlagControllerTest {
         ServerMock server = MockBukkit.mock(new MyCustomServerMock());
         server.getLogger().setLevel(Level.OFF);
         plugin = MockBukkit.load(MockMain.class);
+        Main.logger().setLevel(Level.SEVERE);
         controller = new CaptureTheFlagConfigController(plugin.getDataFolder(), GameType.CAPTURE_THE_FLAG.getId());
         configFolder = new File(plugin.getDataFolder(), GameType.CAPTURE_THE_FLAG.getId());
         configFolder.mkdirs();

--- a/src/test/java/org/braekpo1nt/mctmanager/games/game/clockwork/ClockworkGameTest.java
+++ b/src/test/java/org/braekpo1nt/mctmanager/games/game/clockwork/ClockworkGameTest.java
@@ -5,6 +5,8 @@ import org.braekpo1nt.mctmanager.MockMain;
 import org.braekpo1nt.mctmanager.MyCustomServerMock;
 import org.braekpo1nt.mctmanager.MyPlayerMock;
 import org.braekpo1nt.mctmanager.TestUtils;
+import org.braekpo1nt.mctmanager.commands.manager.commandresult.CommandResult;
+import org.braekpo1nt.mctmanager.commands.manager.commandresult.FailureCommandResult;
 import org.braekpo1nt.mctmanager.games.game.clockwork.config.ClockworkConfigController;
 import org.braekpo1nt.mctmanager.games.game.enums.GameType;
 import org.braekpo1nt.mctmanager.games.gamemanager.GameManager;
@@ -15,13 +17,18 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockbukkit.mockbukkit.MockBukkit;
 import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
 import org.mockbukkit.mockbukkit.exception.UnimplementedOperationException;
 
 import java.io.File;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 public class ClockworkGameTest {
     
@@ -41,6 +48,7 @@ public class ClockworkGameTest {
             Main.logger().log(Level.SEVERE, ex.getMessage(), ex);
             System.exit(1);
         }
+        Main.logger().setLevel(Level.SEVERE);
         gameManager = plugin.getGameManager();
         sender = server.getConsoleSender();
         InputStream inputStream = ClockworkConfigController.class.getResourceAsStream("exampleClockworkConfig.json");
@@ -57,7 +65,12 @@ public class ClockworkGameTest {
     MyPlayerMock createParticipant(String name, String teamId) {
         MyPlayerMock player = new MyPlayerMock(server, name, UUID.nameUUIDFromBytes(name.getBytes(StandardCharsets.UTF_8)));
         server.addPlayer(player);
-        gameManager.joinOnlineParticipant(player, teamId);
+        CompletableFuture<CommandResult> joinFuture = gameManager.joinOnlineParticipant(player, teamId);
+        assertThat(joinFuture)
+                .describedAs("joinOnlineParticipant succeeds without future exception")
+                .isNotCompletedExceptionally();
+        assertThat(joinFuture.join())
+                .isNotInstanceOf(FailureCommandResult.class);
         Assertions.assertNotNull(gameManager.getOnlineParticipant(player.getUniqueId()));
         return player;
     }
@@ -68,14 +81,23 @@ public class ClockworkGameTest {
     }
     
     @Test
+    void testFuture() {
+        PlayerMock playerMock = server.addPlayer("Joe");
+        assertThat(gameManager.illegalMove(playerMock)).isCompletedExceptionally();
+    }
+    
+    @Test
     void testStartGame() {
         addTeam("red", "red", "red");
         addTeam("blue", "blue", "blue");
         createParticipant("Player1", "red");
         createParticipant("Player2", "blue");
-        gameManager.startGame(GameType.CLOCKWORK, "clockworkConfig.json");
+        assertThat(gameManager.startGame(GameType.CLOCKWORK, "clockworkConfig.json"))
+                .describedAs("start game without future exception")
+                .isNotCompletedExceptionally();
         gameManager.getTimerManager().skip();
         gameManager.getTimerManager().skip();
-        gameManager.stopGame(GameType.CLOCKWORK, "clockworkConfig.json");
+        assertThat(gameManager.stopGame(GameType.CLOCKWORK, "clockworkConfig.json"))
+                .isNotCompletedExceptionally();
     }
 }

--- a/src/test/java/org/braekpo1nt/mctmanager/games/game/clockwork/config/ClockworkConfigControllerTest.java
+++ b/src/test/java/org/braekpo1nt/mctmanager/games/game/clockwork/config/ClockworkConfigControllerTest.java
@@ -31,6 +31,7 @@ public class ClockworkConfigControllerTest {
         ServerMock server = MockBukkit.mock(new MyCustomServerMock());
         server.getLogger().setLevel(Level.OFF);
         plugin = MockBukkit.load(MockMain.class);
+        Main.logger().setLevel(Level.SEVERE);
         controller = new ClockworkConfigController(plugin.getDataFolder(), GameType.CLOCKWORK.getId());
         configFolder = new File(plugin.getDataFolder(), GameType.CLOCKWORK.getId());
         configFolder.mkdirs();

--- a/src/test/java/org/braekpo1nt/mctmanager/games/game/colossalcombat/config/ColossalCombatConfigControllerTest.java
+++ b/src/test/java/org/braekpo1nt/mctmanager/games/game/colossalcombat/config/ColossalCombatConfigControllerTest.java
@@ -31,6 +31,7 @@ public class ColossalCombatConfigControllerTest {
         ServerMock server = MockBukkit.mock(new MyCustomServerMock());
         server.getLogger().setLevel(Level.OFF);
         plugin = MockBukkit.load(MockMain.class);
+        Main.logger().setLevel(Level.SEVERE);
         controller = new ColossalCombatConfigController(plugin.getDataFolder(), GameType.FINAL.getId());
         configFolder = new File(plugin.getDataFolder(), GameType.FINAL.getId());
         configFolder.mkdirs();

--- a/src/test/java/org/braekpo1nt/mctmanager/games/game/farmrush/config/FarmRushConfigControllerTest.java
+++ b/src/test/java/org/braekpo1nt/mctmanager/games/game/farmrush/config/FarmRushConfigControllerTest.java
@@ -31,6 +31,7 @@ public class FarmRushConfigControllerTest {
         ServerMock server = MockBukkit.mock(new MyCustomServerMock());
         server.getLogger().setLevel(Level.OFF);
         plugin = MockBukkit.load(MockMain.class);
+        Main.logger().setLevel(Level.SEVERE);
         controller = new FarmRushConfigController(plugin.getDataFolder(), GameType.FARM_RUSH.getId());
         configFolder = new File(plugin.getDataFolder(), GameType.FARM_RUSH.getId());
         configFolder.mkdirs();

--- a/src/test/java/org/braekpo1nt/mctmanager/games/game/finalgame/config/FinalConfigControllerTest.java
+++ b/src/test/java/org/braekpo1nt/mctmanager/games/game/finalgame/config/FinalConfigControllerTest.java
@@ -28,6 +28,7 @@ class FinalConfigControllerTest {
         ServerMock server = MockBukkit.mock(new MyCustomServerMock());
         server.getLogger().setLevel(Level.OFF);
         plugin = MockBukkit.load(MockMain.class);
+        Main.logger().setLevel(Level.SEVERE);
         controller = new FinalConfigController(plugin.getDataFolder(), GameType.FINAL.getId());
         configFolder = new File(plugin.getDataFolder(), GameType.FINAL.getId());
         configFolder.mkdirs();

--- a/src/test/java/org/braekpo1nt/mctmanager/games/game/footrace/config/FootRaceConfigControllerTest.java
+++ b/src/test/java/org/braekpo1nt/mctmanager/games/game/footrace/config/FootRaceConfigControllerTest.java
@@ -32,6 +32,7 @@ class FootRaceConfigControllerTest {
         ServerMock server = MockBukkit.mock(new MyCustomServerMock());
         server.getLogger().setLevel(Level.OFF);
         plugin = MockBukkit.load(MockMain.class);
+        Main.logger().setLevel(Level.SEVERE);
         controller = new FootRaceConfigController(plugin.getDataFolder(), GameType.FOOT_RACE.getId());
         configFolder = new File(plugin.getDataFolder(), GameType.FOOT_RACE.getId());
         configFolder.mkdirs();

--- a/src/test/java/org/braekpo1nt/mctmanager/games/game/parkourpathway/config/ParkourPathwayConfigControllerTest.java
+++ b/src/test/java/org/braekpo1nt/mctmanager/games/game/parkourpathway/config/ParkourPathwayConfigControllerTest.java
@@ -31,6 +31,7 @@ class ParkourPathwayConfigControllerTest {
         ServerMock server = MockBukkit.mock(new MyCustomServerMock());
         server.getLogger().setLevel(Level.OFF);
         plugin = MockBukkit.load(MockMain.class);
+        Main.logger().setLevel(Level.SEVERE);
         controller = new ParkourPathwayConfigController(plugin.getDataFolder(), GameType.PARKOUR_PATHWAY.getId());
         configFolder = new File(plugin.getDataFolder(), GameType.PARKOUR_PATHWAY.getId());
         configFolder.mkdirs();

--- a/src/test/java/org/braekpo1nt/mctmanager/games/game/spleef/config/SpleefConfigControllerTest.java
+++ b/src/test/java/org/braekpo1nt/mctmanager/games/game/spleef/config/SpleefConfigControllerTest.java
@@ -32,6 +32,7 @@ class SpleefConfigControllerTest {
         ServerMock server = MockBukkit.mock(new MyCustomServerMock());
         server.getLogger().setLevel(Level.OFF);
         plugin = MockBukkit.load(MockMain.class);
+        Main.logger().setLevel(Level.SEVERE);
         controller = new SpleefConfigController(plugin.getDataFolder(), GameType.SPLEEF.getId());
         configFolder = new File(plugin.getDataFolder(), GameType.SPLEEF.getId());
         configFolder.mkdirs();

--- a/src/test/java/org/braekpo1nt/mctmanager/games/game/survivalgames/config/SurvivalGamesConfigControllerTest.java
+++ b/src/test/java/org/braekpo1nt/mctmanager/games/game/survivalgames/config/SurvivalGamesConfigControllerTest.java
@@ -31,6 +31,7 @@ class SurvivalGamesConfigControllerTest {
         ServerMock server = MockBukkit.mock(new MyCustomServerMock());
         server.getLogger().setLevel(Level.OFF);
         plugin = MockBukkit.load(MockMain.class);
+        Main.logger().setLevel(Level.SEVERE);
         controller = new SurvivalGamesConfigController(plugin.getDataFolder(), GameType.SURVIVAL_GAMES.getId());
         configFolder = new File(plugin.getDataFolder(), GameType.SURVIVAL_GAMES.getId());
         configFolder.mkdirs();

--- a/src/test/java/org/braekpo1nt/mctmanager/games/gamemanager/GameManagerTest.java
+++ b/src/test/java/org/braekpo1nt/mctmanager/games/gamemanager/GameManagerTest.java
@@ -21,6 +21,8 @@ import java.util.UUID;
 import java.util.logging.Level;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.braekpo1nt.mctmanager.TestUtils.futureIsNotFailure;
+import static org.braekpo1nt.mctmanager.TestUtils.futureIsNotNull;
 
 class GameManagerTest {
     
@@ -41,11 +43,12 @@ class GameManagerTest {
             Main.logger().log(Level.SEVERE, "UnimplementedOperationException from MockBukkit", ex);
             System.exit(1);
         }
+        Main.logger().setLevel(Level.SEVERE);
         gameManager = plugin.getGameManager();
         database = plugin.getDatabase();
         
         teamId = "purple";
-        gameManager.addTeam(teamId, "Purple", "dark_purple");
+        futureIsNotNull(gameManager.addTeam(teamId, "Purple", "dark_purple"));
     }
     
     @AfterEach
@@ -62,7 +65,6 @@ class GameManagerTest {
         // a player who is not in the game state joins
         server.addPlayer(player);
         // this line makes it so that the async schedules the sync task in onPlayerJoin
-        server.getScheduler().waitAsyncTasksFinished();
         server.getScheduler().performOneTick();
         
         AllPlayersEntity allPlayersEntity = database.getAllPlayersDao().queryForId(uuid.toString());
@@ -76,11 +78,10 @@ class GameManagerTest {
         UUID uuid = UUID.randomUUID();
         PlayerMock player = new MyPlayerMock(server, ign, uuid);
         
-        gameManager.joinOfflineParticipant(uuid, ign, teamId);
+        futureIsNotFailure(gameManager.joinOfflineParticipant(uuid, ign, teamId));
         // a player who is in the game state joins
         server.addPlayer(player);
         // this line makes it so that the async schedules the sync task in onPlayerJoin
-        server.getScheduler().waitAsyncTasksFinished();
         server.getScheduler().performOneTick();
         
         AllPlayersEntity allPlayersEntity = database.getAllPlayersDao().queryForId(uuid.toString());
@@ -96,16 +97,14 @@ class GameManagerTest {
         UUID uuid = UUID.randomUUID();
         PlayerMock player = new MyPlayerMock(server, ign, uuid);
         
-        gameManager.joinOfflineParticipant(uuid, ign, teamId);
+        futureIsNotFailure(gameManager.joinOfflineParticipant(uuid, ign, teamId));
         // a player who is in the game state joins
         server.addPlayer(player);
         // this line makes it so that the async schedules the sync task in onPlayerJoin
-        server.getScheduler().waitAsyncTasksFinished();
         server.getScheduler().performOneTick();
         
         player.disconnect();
         server.addPlayer(player);
-        server.getScheduler().waitAsyncTasksFinished();
         server.getScheduler().performOneTick();
         
         AllPlayersEntity allPlayersEntity = database.getAllPlayersDao().queryForId(uuid.toString());
@@ -123,14 +122,11 @@ class GameManagerTest {
         PlayerMock rightPlayer = new MyPlayerMock(server, rightIGN, rightUUID);
         
         // add the wrong uuid but the right ign to the game state
-        gameManager.joinOfflineParticipant(rightUUID, wrongIGN, teamId);
-        // allow TabList to finish scheduled job
-        server.getScheduler().waitAsyncTasksFinished();
+        futureIsNotFailure(gameManager.joinOfflineParticipant(rightUUID, wrongIGN, teamId));
         
         // a player with the right uuid and the right ign joins the server
         server.addPlayer(rightPlayer);
         // this line makes it so that the async schedules the sync task in onPlayerJoin
-        server.getScheduler().waitAsyncTasksFinished();
         server.getScheduler().performOneTick();
         
         List<AllPlayersEntity> playersWithIGN = database.getAllPlayersDao().queryForEq("ign", wrongIGN);
@@ -150,14 +146,10 @@ class GameManagerTest {
         PlayerMock rightPlayer = new MyPlayerMock(server, rightIGN, rightUUID);
         
         // add the wrong uuid but the right ign to the game state
-        gameManager.joinOnlineParticipant(wrongPlayer, teamId);
-        // allow TabList to finish scheduled job
-        server.getScheduler().waitAsyncTasksFinished();
+        futureIsNotFailure(gameManager.joinOnlineParticipant(wrongPlayer, teamId));
         
         // a player with the right uuid and the right ign joins the server
         server.addPlayer(rightPlayer);
-        // this line makes it so that the async schedules the sync task in onPlayerJoin
-        server.getScheduler().waitAsyncTasksFinished();
         server.getScheduler().performOneTick();
         
         AllPlayersEntity wrongAllPlayersEntity = database.getAllPlayersDao().queryForId(wrongUUID.toString());

--- a/src/test/java/org/braekpo1nt/mctmanager/games/gamemanager/MockGameManager.java
+++ b/src/test/java/org/braekpo1nt/mctmanager/games/gamemanager/MockGameManager.java
@@ -16,16 +16,18 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.Executor;
 
 public class MockGameManager extends GameManager {
     public MockGameManager(
-            Main plugin,
-            Scoreboard mctScoreboard,
+            @NotNull Main plugin,
+            @NotNull Scoreboard mctScoreboard,
             @NotNull GameStateStorageUtil gameStateStorageUtil,
             @NotNull SidebarFactory sidebarFactory,
             @NotNull HubConfig config,
             @NotNull Database database,
-            @NotNull GameStateService gameStateService) {
+            @NotNull GameStateService gameStateService,
+            @NotNull Executor mainThreadExecutor) {
         super(
                 plugin,
                 mctScoreboard,
@@ -33,7 +35,8 @@ public class MockGameManager extends GameManager {
                 sidebarFactory,
                 config,
                 database,
-                gameStateService);
+                gameStateService,
+                mainThreadExecutor);
     }
     
     @Override

--- a/src/test/java/org/braekpo1nt/mctmanager/games/gamemanager/RebuildMaintenanceTest.java
+++ b/src/test/java/org/braekpo1nt/mctmanager/games/gamemanager/RebuildMaintenanceTest.java
@@ -3,7 +3,6 @@ package org.braekpo1nt.mctmanager.games.gamemanager;
 import org.braekpo1nt.mctmanager.Main;
 import org.braekpo1nt.mctmanager.MockMain;
 import org.braekpo1nt.mctmanager.MyCustomServerMock;
-import org.braekpo1nt.mctmanager.MyPlayerMock;
 import org.braekpo1nt.mctmanager.commands.manager.commandresult.FailureCommandResult;
 import org.braekpo1nt.mctmanager.database.Database;
 import org.braekpo1nt.mctmanager.database.entities.GameSession;
@@ -22,11 +21,14 @@ import org.mockbukkit.mockbukkit.ServerMock;
 import org.mockbukkit.mockbukkit.entity.PlayerMock;
 import org.mockbukkit.mockbukkit.exception.UnimplementedOperationException;
 
+import java.sql.SQLException;
 import java.util.Date;
 import java.util.UUID;
 import java.util.logging.Level;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.braekpo1nt.mctmanager.TestUtils.futureIsNotFailure;
+import static org.braekpo1nt.mctmanager.TestUtils.futureIsNotNull;
 
 public class RebuildMaintenanceTest {
     ServerMock server;
@@ -52,6 +54,7 @@ public class RebuildMaintenanceTest {
             Main.logger().log(Level.SEVERE, "UnimplementedOperationException from MockBukkit", ex);
             System.exit(1);
         }
+        Main.logger().setLevel(Level.SEVERE);
         gameManager = plugin.getGameManager();
         database = plugin.getDatabase();
         scoreService = gameManager.getScoreService();
@@ -61,18 +64,17 @@ public class RebuildMaintenanceTest {
         uuid1 = UUID.randomUUID();
         ign1 = "Player1";
         
-        gameManager.addTeam(teamId1, "Red", "red");
-        gameManager.joinOfflineParticipant(uuid1, ign1, teamId1);
+        futureIsNotNull(gameManager.addTeam(teamId1, "Red", "red"));
+        futureIsNotFailure(gameManager.joinOfflineParticipant(uuid1, ign1, teamId1));
     }
     
     @AfterEach
     void tearDownServerAndPlugin() {
-        server.getScheduler().waitAsyncTasksFinished();
         MockBukkit.unmock();
     }
     
     @Test
-    void test() {
+    void test() throws SQLException {
         double multiplier = 1.5;
         GameSession gameSession = scoreService.createGameSession(GameSession.builder()
                 .gameType(GameType.FOOT_RACE)
@@ -95,8 +97,7 @@ public class RebuildMaintenanceTest {
                 .createdAt(new Date())
                 .build());
         assertThat(scoreEventEntity).isNotNull();
-        assertThat(gameManager.loadGameState()).isNotInstanceOf(FailureCommandResult.class);
-        server.getScheduler().waitAsyncTasksFinished();
+        futureIsNotFailure(gameManager.loadGameState());
         server.getScheduler().performOneTick();
         OfflineParticipant offlineParticipant = gameManager.getOfflineParticipant(uuid1);
         assertThat(offlineParticipant).isNotNull();

--- a/src/test/java/org/braekpo1nt/mctmanager/games/gamemanager/RebuildTest.java
+++ b/src/test/java/org/braekpo1nt/mctmanager/games/gamemanager/RebuildTest.java
@@ -6,7 +6,7 @@ import org.braekpo1nt.mctmanager.MockMain;
 import org.braekpo1nt.mctmanager.MyCustomServerMock;
 import org.braekpo1nt.mctmanager.MyPlayerMock;
 import org.braekpo1nt.mctmanager.TestUtils;
-import org.braekpo1nt.mctmanager.commands.manager.commandresult.FailureCommandResult;
+import org.braekpo1nt.mctmanager.commands.manager.commandresult.CommandResult;
 import org.braekpo1nt.mctmanager.database.Database;
 import org.braekpo1nt.mctmanager.database.entities.EventInfo;
 import org.braekpo1nt.mctmanager.database.entities.participants.EventParticipantEntity;
@@ -21,6 +21,7 @@ import org.braekpo1nt.mctmanager.games.gamemanager.event.config.EventConfigContr
 import org.braekpo1nt.mctmanager.participant.Participant;
 import org.braekpo1nt.mctmanager.participant.Team;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockbukkit.mockbukkit.MockBukkit;
@@ -36,9 +37,11 @@ import java.sql.SQLException;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.braekpo1nt.mctmanager.TestUtils.futureIsNotFailure;
 
 class RebuildTest {
     ServerMock server;
@@ -71,6 +74,7 @@ class RebuildTest {
             Main.logger().log(Level.SEVERE, "UnimplementedOperationException from MockBukkit", ex);
             System.exit(1);
         }
+        Main.logger().setLevel(Level.SEVERE);
         gameManager = plugin.getGameManager();
         database = plugin.getDatabase();
         scoreService = gameManager.getScoreService();
@@ -101,7 +105,7 @@ class RebuildTest {
         
         Date now = new Date();
         eventId = "Test";
-        gameManager.createEvent(eventId, now, "Test Event", Component.text("Test Event"), true);
+        futureIsNotFailure(gameManager.createEvent(eventId, now, "Test Event", Component.text("Test Event"), true));
         eventInfo = gameManager.getEventService().getEventInfo(eventId);
         List<EventTeam> teams = List.of(
                 EventTeam.builder()
@@ -139,20 +143,18 @@ class RebuildTest {
     
     @AfterEach
     void tearDownServerAndPlugin() {
-        server.getScheduler().waitAsyncTasksFinished();
         server.getScheduler().performOneTick();
         MockBukkit.unmock();
     }
     
     @Test
     void testSum() {
-        assertThat(gameManager.startEvent(eventInfo, 7, 2)).isNotInstanceOf(FailureCommandResult.class);
+        futureIsNotFailure(gameManager.startEvent(eventInfo, 7, 2));
         assertThat(gameManager.getOnlineParticipants()).hasSize(2);
-        assertThat(gameManager.startEvent(eventInfo, 7, 2)).isNotInstanceOf(FailureCommandResult.class);
+        futureIsNotFailure(gameManager.startEvent(eventInfo, 7, 2));
         assertThat(gameManager.getMultiplier()).isEqualTo(1.5);
-        assertThat(gameManager.startGame(GameType.FOOT_RACE, "default.json")).isNotInstanceOf(FailureCommandResult.class);
+        futureIsNotFailure(gameManager.startGame(GameType.FOOT_RACE, "default.json"));
         gameManager.getTimerManager().skip();
-        server.getScheduler().waitAsyncTasksFinished();
         server.getScheduler().performOneTick();
         assertThat(gameManager.getActiveGameIds()).hasSize(1);
         MCTGame activeGame = gameManager.getActiveGame(new GameInstanceId(GameType.FOOT_RACE, "default.json"));
@@ -164,7 +166,7 @@ class RebuildTest {
         assertThat(participant1.getScore()).isEqualTo(0);
         game.awardPoints(participant1, 1, "Test points 1");
         assertThat(participant1.getScore()).isEqualTo(1);
-        gameManager.stopGame(GameType.FOOT_RACE, "default.json");
+        futureIsNotFailure(gameManager.stopGame(GameType.FOOT_RACE, "default.json"));
         Participant pPreLoad = gameManager.getOnlineParticipant(uuid1);
         assertThat(pPreLoad).isNotNull();
         assertThat(pPreLoad.getScore()).isEqualTo(1);
@@ -172,9 +174,8 @@ class RebuildTest {
         assertThat(teamPreLoad).isNotNull();
         assertThat(teamPreLoad.getScore()).isEqualTo(1);
         
-        assertThat(gameManager.loadGameState()).isNotInstanceOf(FailureCommandResult.class);
+        futureIsNotFailure(gameManager.loadGameState());
         assertThat(gameManager.getMode()).isEqualTo(Mode.EVENT);
-        server.getScheduler().waitAsyncTasksFinished();
         server.getScheduler().performOneTick();
         
         Participant pPostLoad = gameManager.getOnlineParticipant(uuid1);
@@ -184,8 +185,7 @@ class RebuildTest {
         assertThat(teamPostLoad).isNotNull();
         assertThat(teamPostLoad.getScore()).isEqualTo(1);
         
-        gameManager.stopEvent();
-        server.getScheduler().waitAsyncTasksFinished();
+        futureIsNotFailure(gameManager.stopEvent());
         server.getScheduler().performOneTick();
     }
     

--- a/src/test/java/org/braekpo1nt/mctmanager/games/gamestate/GameStateStorageUtilTest.java
+++ b/src/test/java/org/braekpo1nt/mctmanager/games/gamestate/GameStateStorageUtilTest.java
@@ -33,7 +33,7 @@ public class GameStateStorageUtilTest {
     void setup() throws IOException, SQLException {
         dbPath = Files.createTempFile("test-db-", "mctmanager.db");
         String sqlitePath = dbPath.toAbsolutePath().toString();
-        database = new Database(sqlitePath);
+        database = new Database(sqlitePath, Runnable::run);
         
         Logger logger = Logger.getLogger("test");
         logger.setLevel(Level.OFF);
@@ -71,7 +71,7 @@ public class GameStateStorageUtilTest {
         String ign = "Player1";
         
         assertThat(gameStateStorageUtil.registerPlayer(uuid, ign)).isEqualTo(RegisterConflictType.NONE);
-        gameStateStorageUtil.addNewPlayer(uuid, ign, teamId);
+        gameStateStorageUtil.joinPlayer(uuid, ign, teamId);
         
         AllPlayersEntity actual = database.getAllPlayersDao().queryForId(uuid.toString());
         assertThat(actual).isNotNull();
@@ -87,7 +87,7 @@ public class GameStateStorageUtilTest {
         String ign = "Player1";
         
         assertThat(gameStateStorageUtil.registerPlayer(uuid, ign)).isEqualTo(RegisterConflictType.NONE);
-        gameStateStorageUtil.addNewPlayer(uuid, ign, teamId);
+        gameStateStorageUtil.joinPlayer(uuid, ign, teamId);
         assertThat(gameStateStorageUtil.registerPlayer(uuid, ign)).isEqualTo(RegisterConflictType.NONE);
         
         AllPlayersEntity actual = database.getAllPlayersDao().queryForId(uuid.toString());
@@ -103,7 +103,7 @@ public class GameStateStorageUtilTest {
         UUID uuid = UUID.randomUUID();
         String ign = "Player1";
         
-        gameStateStorageUtil.addNewPlayer(uuid, ign, teamId);
+        gameStateStorageUtil.joinPlayer(uuid, ign, teamId);
         gameStateStorageUtil.leavePlayer(uuid);
         
         AllPlayersEntity actual = database.getAllPlayersDao().queryForId(uuid.toString());
@@ -118,9 +118,9 @@ public class GameStateStorageUtilTest {
         UUID uuid = UUID.randomUUID();
         String ign = "Player1";
         
-        gameStateStorageUtil.addNewPlayer(uuid, ign, teamId);
+        gameStateStorageUtil.joinPlayer(uuid, ign, teamId);
         gameStateStorageUtil.leavePlayer(uuid);
-        gameStateStorageUtil.addNewPlayer(uuid, ign, teamId);
+        gameStateStorageUtil.joinPlayer(uuid, ign, teamId);
         
         AllPlayersEntity actual = database.getAllPlayersDao().queryForId(uuid.toString());
         assertThat(actual).isNotNull();
@@ -137,7 +137,7 @@ public class GameStateStorageUtilTest {
         String correctIGN = "Player1";
         
         // offline player added to game state, wrong ign
-        gameStateStorageUtil.addNewPlayer(uuid, wrongIGN, teamId);
+        gameStateStorageUtil.joinPlayer(uuid, wrongIGN, teamId);
         
         // player with that uuid and a different ign logs in
         assertThat(gameStateStorageUtil.registerPlayer(uuid, correctIGN)).isEqualTo(RegisterConflictType.MIGRATE_IGN);
@@ -159,7 +159,7 @@ public class GameStateStorageUtilTest {
         String ign = "Player1";
         
         // offline player added to game state, wrong uuid
-        gameStateStorageUtil.addNewPlayer(wrongUUID, ign, teamId);
+        gameStateStorageUtil.joinPlayer(wrongUUID, ign, teamId);
         
         // player with that username but a different uuid logs in
         assertThat(gameStateStorageUtil.registerPlayer(rightUUID, ign)).isEqualTo(RegisterConflictType.MIGRATE_UUID);
@@ -182,9 +182,9 @@ public class GameStateStorageUtilTest {
         String rightIGN = "Player1";
         
         // offline player added to game state, wrong ign
-        gameStateStorageUtil.addNewPlayer(rightUUID, wrongIGN, teamId);
+        gameStateStorageUtil.joinPlayer(rightUUID, wrongIGN, teamId);
         // offline player added to the game state, wrong uuid right ign
-        gameStateStorageUtil.addNewPlayer(wrongUUID, rightIGN, teamId);
+        gameStateStorageUtil.joinPlayer(wrongUUID, rightIGN, teamId);
         
         // player with the right uuid and ign combo logs in
         assertThat(gameStateStorageUtil.registerPlayer(rightUUID, rightIGN)).isEqualTo(RegisterConflictType.MIGRATE_UUID);

--- a/src/test/java/org/braekpo1nt/mctmanager/games/gamestate/MockGameStateStorageUtil.java
+++ b/src/test/java/org/braekpo1nt/mctmanager/games/gamestate/MockGameStateStorageUtil.java
@@ -8,7 +8,7 @@ import java.util.logging.Logger;
 public class MockGameStateStorageUtil extends GameStateStorageUtil {
     
     public MockGameStateStorageUtil(Logger logger, GameStateService gameStateService) {
-        super(logger, gameStateService, false);
+        super(logger, gameStateService, Runnable::run, false);
     }
 
 //    @Override

--- a/src/test/java/org/braekpo1nt/mctmanager/hub/config/HubConfigControllerTest.java
+++ b/src/test/java/org/braekpo1nt/mctmanager/hub/config/HubConfigControllerTest.java
@@ -29,6 +29,7 @@ public class HubConfigControllerTest {
         ServerMock server = MockBukkit.mock(new MyCustomServerMock());
         server.getLogger().setLevel(Level.OFF);
         plugin = MockBukkit.load(MockMain.class);
+        Main.logger().setLevel(Level.SEVERE);
         controller = new HubConfigController(plugin.getDataFolder());
     }
     

--- a/src/test/java/org/braekpo1nt/mctmanager/ui/tablist/MockTabList.java
+++ b/src/test/java/org/braekpo1nt/mctmanager/ui/tablist/MockTabList.java
@@ -7,14 +7,4 @@ public class MockTabList extends TabList {
     public MockTabList(@NotNull Main plugin) {
         super(plugin);
     }
-    
-    @Override
-    protected void scheduleAsync(Runnable runnable) {
-        runnable.run();
-    }
-    
-    @Override
-    protected void scheduleSync(Runnable runnable) {
-        runnable.run();
-    }
 }

--- a/src/test/java/org/braekpo1nt/mctmanager/ui/timer/TimerManagerTest.java
+++ b/src/test/java/org/braekpo1nt/mctmanager/ui/timer/TimerManagerTest.java
@@ -20,6 +20,9 @@ import java.io.File;
 import java.io.InputStream;
 import java.util.logging.Level;
 
+import static org.braekpo1nt.mctmanager.TestUtils.futureIsNotFailure;
+import static org.braekpo1nt.mctmanager.TestUtils.futureIsNotNull;
+
 class TimerManagerTest {
     
     private TimerManager timerManager;
@@ -36,12 +39,15 @@ class TimerManagerTest {
             gameManager = plugin.getGameManager();
             timerManager = gameManager.getTimerManager();
             InputStream inputStream = FootRaceConfig.class.getResourceAsStream("exampleFootRaceConfig.json");
-            TestUtils.copyInputStreamToFile(inputStream, new File(plugin.getDataFolder(), "footRaceConfig.json"));
+            File configFolder = new File(plugin.getDataFolder(), "foot-race/");
+            configFolder.mkdirs();
+            TestUtils.copyInputStreamToFile(inputStream, new File(configFolder, "footRaceConfig.json"));
         } catch (UnimplementedOperationException ex) {
             System.out.println("UnimplementedOperationException while setting up " + this.getClass() + ". MockBukkit must not support the functionality/operation you are trying to test. Check the stack trace below for the exact method that threw the exception. Message from exception:" + ex.getMessage());
             Main.logger().log(Level.SEVERE, "error occurred in MockBukkit", ex);
             System.exit(1);
         }
+        Main.logger().setLevel(Level.SEVERE);
     }
     
     @AfterEach
@@ -61,9 +67,9 @@ class TimerManagerTest {
     @Test
     void footRace() {
         PlayerMock playerMock = server.addPlayer();
-        gameManager.addTeam("test", "Test", "white");
-        gameManager.joinOnlineParticipant(playerMock, "test");
-        gameManager.startGame(GameType.FOOT_RACE, "footRaceConfig.json");
+        futureIsNotNull(gameManager.addTeam("test", "Test", "white"));
+        futureIsNotFailure(gameManager.joinOnlineParticipant(playerMock, "test"));
+        futureIsNotFailure(gameManager.startGame(GameType.FOOT_RACE, "footRaceConfig.json"));
         Assertions.assertDoesNotThrow(timerManager::skip);
     }
     


### PR DESCRIPTION
closes #830 

- All database interactions happen in `CompletableFuture`s
- Replaced all calls to `plugin.getServer().getScheduler().runTaskAsynchronously()` with `CompletableFuture` implementation instead
- Provided a `mainThreadExecutor` and a `databaseExecutor`, both of which are injectable and can thus be mocked for linear testing in unit tests
- Removed `CommandResult` async variants and replaced with `CompletableFuture<ComandResult>`
  - also modified brigadier command wrapper to accept both raw `CommandResult` and `CompletableFuture<ComandResult>`
  - Other tweaks and fixes