### PR TITLE
872 survival games points bug

### DIFF
--- a/src/main/java/org/braekpo1nt/mctmanager/games/game/survivalgames/Border.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/game/survivalgames/Border.java
@@ -73,7 +73,7 @@ public class Border {
      * The loadout to be given to a participant upon respawning.
      * Can't be null, can be empty
      */
-    private @NotNull ItemStack[] respawnLoadout;
+    private ItemStack @NotNull [] respawnLoadout;
     /**
      * The number of deaths that grant kill points. E.g. if 2, then the first two times
      * a participant is killed, the killer gets points.
@@ -82,6 +82,12 @@ public class Border {
      * Defaults to -1
      */
     private int deathPointsThreshold;
+    /**
+     * True if, during respawn phases, you should divide the points awarded for each kill
+     * by the number of kills the killer currently has (including the kill being awarded for).
+     * Defaults to false.
+     */
+    private boolean dividePointsByKills;
     /**
      * If true, a participant in their {@link #respawnGracePeriodTime} can attack other participants.
      * If false, a participant can't deal damage when in grace period.

--- a/src/main/java/org/braekpo1nt/mctmanager/games/game/survivalgames/config/BorderDTO.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/game/survivalgames/config/BorderDTO.java
@@ -82,6 +82,12 @@ class BorderDTO implements Validatable {
      */
     private @Nullable Integer deathPointsThreshold;
     /**
+     * True if, during respawn phases, you should divide the points awarded for each kill
+     * by the number of kills the killer currently has (including the kill being awarded for).
+     * Defaults to false.
+     */
+    private @Nullable Boolean dividePointsByKills;
+    /**
      * If true, a participant in their {@link #respawnGracePeriodTime} can attack other participants.
      * If false, a participant can't deal damage when in grace period.
      * Defaults to true.
@@ -129,6 +135,7 @@ class BorderDTO implements Validatable {
                 .respawnLocations(respawnLocations != null ? LocationDTO.toLocations(respawnLocations, world) : Collections.emptyList())
                 .respawnLoadout(this.respawnLoadout != null ? this.respawnLoadout.toInventoryContents() : new ItemStack[0])
                 .deathPointsThreshold(this.deathPointsThreshold != null ? this.deathPointsThreshold : -1)
+                .dividePointsByKills(this.dividePointsByKills != null ? this.dividePointsByKills : false)
                 .canAttackWhenRespawning(this.canAttackWhenRespawning != null ? this.canAttackWhenRespawning : true)
                 .stages(BorderStageDTO.toBorderStages(borderStages))
                 .build();

--- a/src/main/java/org/braekpo1nt/mctmanager/games/game/survivalgames/config/SurvivalGamesConfig.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/game/survivalgames/config/SurvivalGamesConfig.java
@@ -40,6 +40,7 @@ public class SurvivalGamesConfig implements Config {
     private int roundOverDuration;
     private int killScore;
     private int surviveTeamScore;
+    private int surviveParticipantScore;
     private int firstPlaceScore;
     private int secondPlaceScore;
     private int thirdPlaceScore;

--- a/src/main/java/org/braekpo1nt/mctmanager/games/game/survivalgames/config/SurvivalGamesConfigDTO.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/game/survivalgames/config/SurvivalGamesConfigDTO.java
@@ -240,6 +240,7 @@ class SurvivalGamesConfigDTO implements Validatable {
                 .killScore(this.scores.kill)
                 .starterLoadout(this.starterLoadout != null ? this.starterLoadout.toInventoryContents() : null)
                 .surviveTeamScore(this.scores.surviveTeam)
+                .surviveParticipantScore(this.scores.surviveParticipant != null ? this.scores.surviveParticipant : this.scores.surviveTeam / 8)
                 .firstPlaceScore(this.scores.firstPlace)
                 .secondPlaceScore(this.scores.secondPlace)
                 .thirdPlaceScore(this.scores.thirdPlace)
@@ -286,7 +287,17 @@ class SurvivalGamesConfigDTO implements Validatable {
     record Platform(BoundingBox barrier, YawPitch facingDirection) {
     }
     
-    record Scores(int kill, int surviveTeam, int firstPlace, int secondPlace, int thirdPlace) {
+    @Data
+    static class Scores {
+        private int kill;
+        private int surviveTeam;
+        /**
+         * Defaults to {@link #surviveTeam}/8 if not specified
+         */
+        private @Nullable Integer surviveParticipant;
+        private int firstPlace;
+        private int secondPlace;
+        private int thirdPlace;
     }
     
     @Data

--- a/src/main/java/org/braekpo1nt/mctmanager/games/game/survivalgames/states/RoundActiveState.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/game/survivalgames/states/RoundActiveState.java
@@ -261,8 +261,8 @@ public abstract class RoundActiveState extends SurvivalGamesStateBase {
     private void onParticipantPermaDeath(SurvivalGamesParticipant participant) {
         // respawning is disabled, meaning this is a final kill, and survival points should be awarded
         // Yes, the `killer` should also get survival points
-        List<SurvivalGamesParticipant> livingParticipants = getLivingParticipants();
-        context.awardParticipantPoints(livingParticipants, config.getSurviveParticipantScore(), String.format("Outlasted \"%s\"", participant.getName()));
+        List<SurvivalGamesParticipant> livingParticipantsNotOnTeam = getLivingParticipantsExcept(participant.getTeamId());
+        context.awardParticipantPoints(livingParticipantsNotOnTeam, config.getSurviveParticipantScore(), String.format("Outlasted \"%s\"", participant.getName()));
     }
     
     /**
@@ -509,6 +509,16 @@ public abstract class RoundActiveState extends SurvivalGamesStateBase {
     private @NotNull List<SurvivalGamesParticipant> getLivingParticipants() {
         return context.getParticipants().values().stream()
                 .filter(SurvivalGamesParticipant::isAlive)
+                .toList();
+    }
+    
+    /**
+     * @param exceptTeamId the teamId to NOT include members of in the resulting list
+     * @return all living participants who are not on the given team
+     */
+    private @NotNull List<SurvivalGamesParticipant> getLivingParticipantsExcept(@NotNull String exceptTeamId) {
+        return context.getParticipants().values().stream()
+                .filter(p -> p.isAlive() && !p.getTeamId().equals(exceptTeamId))
                 .toList();
     }
     

--- a/src/main/java/org/braekpo1nt/mctmanager/games/game/survivalgames/states/RoundActiveState.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/game/survivalgames/states/RoundActiveState.java
@@ -9,6 +9,7 @@ import org.braekpo1nt.mctmanager.games.game.survivalgames.SurvivalGamesGame;
 import org.braekpo1nt.mctmanager.games.game.survivalgames.SurvivalGamesParticipant;
 import org.braekpo1nt.mctmanager.games.game.survivalgames.SurvivalGamesTeam;
 import org.braekpo1nt.mctmanager.games.game.survivalgames.config.SurvivalGamesConfig;
+import org.braekpo1nt.mctmanager.games.utils.GameManagerUtils;
 import org.braekpo1nt.mctmanager.ui.TimeStringUtils;
 import org.braekpo1nt.mctmanager.ui.UIUtils;
 import org.braekpo1nt.mctmanager.ui.sidebar.Sidebar;
@@ -218,9 +219,12 @@ public abstract class RoundActiveState extends SurvivalGamesStateBase {
     @Override
     public void onParticipantDeath(@NotNull PlayerDeathEvent event, @NotNull SurvivalGamesParticipant participant) {
         event.setDroppedExp(0);
+        Main.logf("onParticipantDeath(%s)", participant.getName());
         if (participant.getKiller() != null) {
+            Main.logf("killer is not null");
             SurvivalGamesParticipant killer = context.getParticipants().get(participant.getKiller().getUniqueId());
             if (killer != null) {
+                Main.logf("killer is not null 2");
                 onParticipantGetKill(killer, participant);
             }
         }
@@ -249,10 +253,19 @@ public abstract class RoundActiveState extends SurvivalGamesStateBase {
         }
         if (allowRespawn()) {
             initiateParticipantRespawnCountdown(participant);
+        } else {
+            onParticipantPermaDeath(participant);
         }
         if (!team.isAlive()) {
             onTeamDeath(context.getTeams().get(teamId));
         }
+    }
+    
+    private void onParticipantPermaDeath(SurvivalGamesParticipant participant) {
+        // respawning is disabled, meaning this is a final kill, and survival points should be awarded
+        // Yes, the `killer` should also get survival points
+        List<SurvivalGamesParticipant> livingParticipants = getLivingParticipants();
+        context.awardParticipantPoints(livingParticipants, config.getSurviveParticipantScore(), String.format("Outlasted \"%s\"", participant.getName()));
     }
     
     /**
@@ -375,25 +388,61 @@ public abstract class RoundActiveState extends SurvivalGamesStateBase {
     }
     
     private void onParticipantGetKill(@NotNull SurvivalGamesParticipant killer, @NotNull SurvivalGamesParticipant killed) {
+        Main.logf("onParticipantGetKill");
         addKill(killer);
         UIUtils.showKillTitle(killer, killed);
-        if (!killer.getTeamId().equals(killed.getTeamId())) {
-            // if all deaths grant points, or this specific death for this killed participant should grant points
-            int deathPointsThreshold = config.getBorder().getDeathPointsThreshold();
-            if (deathPointsThreshold < 0 || killed.getDeaths() < deathPointsThreshold) {
-                // killer.getKills() should return the new kill count, so it should never be 0. This is a precaution.
-                if (!allowRespawn() || killer.getKills() == 0) {
+        if (killer.sameTeam(killed)) {
+            return;
+        }
+        int deathPointsThreshold = config.getBorder().getDeathPointsThreshold();
+        if (allowRespawn()) {
+            Main.logf("allowRespawn() is true");
+            // this is a temporary death
+            if (deathPointsThreshold >= 0) {
+                Main.logf("deathPointsThreshold is %s", deathPointsThreshold);
+                if (killed.getDeaths() < deathPointsThreshold) {
+                    // points are still awarded for this death
                     context.awardPoints(killer, config.getKillScore(), String.format("Killed \"%s\"", killed.getName()));
-                    }
                 } else {
-                    int killPoints = config.getKillScore() / killer.getKills();
+                    killer.sendMessage(Component.empty()
+                            .append(killed.displayName())
+                            .append(Component.text(" was killed more than "))
+                            .append(Component.text(deathPointsThreshold))
+                            .append(Component.text(" time(s). No kill points."))
+                    );
+                }
+            } else {
+                Main.logf("deathPointsThreshold is negative");
+                // no death point threshold in effect, just award modified kill points
+                int killPoints = config.getKillScore() / killer.getKills();
+                if (killPoints > 0) {
                     context.awardPoints(killer, killPoints, String.format("Killed \"%s\"", killed.getName()));
+                } else {
+                    killer.sendMessage(Component.empty()
+                            .append(killed.displayName())
+                            .append(Component.text(" this was your "))
+                            .append(Component.text(GameManagerUtils.getStandingSuffix(killer.getKills())))
+                            .append(Component.text(" kill. No kill points till respawning is enabled."))
+                    );
                 }
             }
-            if (!allowRespawn()) {
-                List<SurvivalGamesParticipant> livingParticipants = getLivingParticipants();
-                for(SurvivalGamesParticipant livingParticipant : livingParticipants) {
-                    context.awardPoints(livingParticipant, config.getSurviveTeamScore()/8, String.format("Outlasted \"%s\"", killed.getName()));
+        } else {
+            // this is a perma-death
+            if (deathPointsThreshold >= 0) {
+                if (killed.getDeaths() < deathPointsThreshold) {
+                    // points are still awarded for this death
+                    context.awardPoints(killer, config.getKillScore(), String.format("Killed \"%s\"", killed.getName()));
+                } else {
+                    killer.sendMessage(Component.empty()
+                            .append(killed.displayName())
+                            .append(Component.text(" was killed more than "))
+                            .append(Component.text(deathPointsThreshold))
+                            .append(Component.text(" time(s). No kill points."))
+                    );
+                }
+            } else {
+                // award kill points straight up for perma-death
+                context.awardPoints(killer, config.getKillScore(), String.format("Killed \"%s\"", killed.getName()));
             }
         }
     }

--- a/src/main/java/org/braekpo1nt/mctmanager/games/game/survivalgames/states/RoundActiveState.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/game/survivalgames/states/RoundActiveState.java
@@ -391,52 +391,35 @@ public abstract class RoundActiveState extends SurvivalGamesStateBase {
             return;
         }
         int deathPointsThreshold = config.getBorder().getDeathPointsThreshold();
+        if (deathPointsThreshold >= 0 && (killed.getDeaths() >= deathPointsThreshold)) {
+            killer.sendMessage(Component.empty()
+                    .append(killed.displayName())
+                    .append(Component.text(" was killed more than "))
+                    .append(Component.text(deathPointsThreshold))
+                    .append(Component.text(" time(s). No kill points."))
+            );
+            return;
+        }
         if (allowRespawn()) {
-            // this is a temporary death
-            if (deathPointsThreshold >= 0) {
-                if (killed.getDeaths() < deathPointsThreshold) {
-                    // points are still awarded for this death
-                    context.awardPoints(killer, config.getKillScore(), String.format("Killed \"%s\"", killed.getName()));
-                } else {
-                    killer.sendMessage(Component.empty()
-                            .append(killed.displayName())
-                            .append(Component.text(" was killed more than "))
-                            .append(Component.text(deathPointsThreshold))
-                            .append(Component.text(" time(s). No kill points."))
-                    );
-                }
+            // This is a temporary death:
+            // Kill points may optionally be divided by number of kills, according to config.
+            int killPoints = config.getBorder().isDividePointsByKills() ? config.getKillScore() / killer.getKills() : config.getKillScore();
+            if (killPoints > 0) {
+                context.awardPoints(killer, killPoints, String.format("Killed \"%s\"", killed.getName()));
             } else {
-                // no death point threshold in effect, just award modified kill points
-                int killPoints = config.getKillScore() / killer.getKills();
-                if (killPoints > 0) {
-                    context.awardPoints(killer, killPoints, String.format("Killed \"%s\"", killed.getName()));
-                } else {
-                    killer.sendMessage(Component.empty()
-                            .append(killed.displayName())
-                            .append(Component.text(" this was your "))
-                            .append(Component.text(GameManagerUtils.getStandingSuffix(killer.getKills())))
-                            .append(Component.text(" kill. No kill points till respawning is enabled."))
-                    );
-                }
+                killer.sendMessage(Component.empty()
+                        .append(killed.displayName())
+                        .append(Component.text(" this was your "))
+                        .append(Component.text(killer.getKills()))
+                        .append(Component.text(GameManagerUtils.getStandingSuffix(killer.getKills())))
+                        .append(Component.text(" kill. No kill points till respawning is enabled."))
+                );
             }
         } else {
             // this is a perma-death
-            if (deathPointsThreshold >= 0) {
-                if (killed.getDeaths() < deathPointsThreshold) {
-                    // points are still awarded for this death
-                    context.awardPoints(killer, config.getKillScore(), String.format("Killed \"%s\"", killed.getName()));
-                } else {
-                    killer.sendMessage(Component.empty()
-                            .append(killed.displayName())
-                            .append(Component.text(" was killed more than "))
-                            .append(Component.text(deathPointsThreshold))
-                            .append(Component.text(" time(s). No kill points."))
-                    );
-                }
-            } else {
-                // award kill points straight up for perma-death
-                context.awardPoints(killer, config.getKillScore(), String.format("Killed \"%s\"", killed.getName()));
-            }
+            // award kill points straight up for perma-death
+            context.awardPoints(killer, config.getKillScore(), String.format("Killed \"%s\"", killed.getName()));
+            
         }
     }
     

--- a/src/main/java/org/braekpo1nt/mctmanager/games/game/survivalgames/states/RoundActiveState.java
+++ b/src/main/java/org/braekpo1nt/mctmanager/games/game/survivalgames/states/RoundActiveState.java
@@ -219,12 +219,9 @@ public abstract class RoundActiveState extends SurvivalGamesStateBase {
     @Override
     public void onParticipantDeath(@NotNull PlayerDeathEvent event, @NotNull SurvivalGamesParticipant participant) {
         event.setDroppedExp(0);
-        Main.logf("onParticipantDeath(%s)", participant.getName());
         if (participant.getKiller() != null) {
-            Main.logf("killer is not null");
             SurvivalGamesParticipant killer = context.getParticipants().get(participant.getKiller().getUniqueId());
             if (killer != null) {
-                Main.logf("killer is not null 2");
                 onParticipantGetKill(killer, participant);
             }
         }
@@ -388,7 +385,6 @@ public abstract class RoundActiveState extends SurvivalGamesStateBase {
     }
     
     private void onParticipantGetKill(@NotNull SurvivalGamesParticipant killer, @NotNull SurvivalGamesParticipant killed) {
-        Main.logf("onParticipantGetKill");
         addKill(killer);
         UIUtils.showKillTitle(killer, killed);
         if (killer.sameTeam(killed)) {
@@ -396,10 +392,8 @@ public abstract class RoundActiveState extends SurvivalGamesStateBase {
         }
         int deathPointsThreshold = config.getBorder().getDeathPointsThreshold();
         if (allowRespawn()) {
-            Main.logf("allowRespawn() is true");
             // this is a temporary death
             if (deathPointsThreshold >= 0) {
-                Main.logf("deathPointsThreshold is %s", deathPointsThreshold);
                 if (killed.getDeaths() < deathPointsThreshold) {
                     // points are still awarded for this death
                     context.awardPoints(killer, config.getKillScore(), String.format("Killed \"%s\"", killed.getName()));
@@ -412,7 +406,6 @@ public abstract class RoundActiveState extends SurvivalGamesStateBase {
                     );
                 }
             } else {
-                Main.logf("deathPointsThreshold is negative");
                 // no death point threshold in effect, just award modified kill points
                 int killPoints = config.getKillScore() / killer.getKills();
                 if (killPoints > 0) {


### PR DESCRIPTION
closes #872 

- added `dividePointsByKills` to config, if true then kills during the respawn periods will give `kill-points/number-of-kills` points instead of full `kill-points`
- added `surviveParticipant` to config, defaults to `surviveTeam/8` if not specified
- when a participant is killed permanently, living participants not on the same team get `surviveParticipant` points
- fixed `onParticipantGetKill()` to award points properly, according to above notes. 

